### PR TITLE
Cache Gem version checks with a variable

### DIFF
--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -3,19 +3,20 @@
 module Goldiloader
   module Compatibility
 
+    MASS_ASSIGNMENT_SECURITY = (::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity))
+    ASSOCIATION_FINDER_SQL = (::Gem::Version.new(::ActiveRecord::VERSION::STRING) < ::Gem::Version.new('4.1'))
+    UNSCOPE_QUERY_METHOD = (::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new('4.1'))
+
     def self.mass_assignment_security_enabled?
-      @mass_assignment_security_enabled = (::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity)) unless defined?(@mass_assignment_security_enabled)
-      @mass_assignment_security_enabled
+      MASS_ASSIGNMENT_SECURITY
     end
 
     def self.association_finder_sql_enabled?
-      @association_finder_sql = (::Gem::Version.new(::ActiveRecord::VERSION::STRING) < ::Gem::Version.new('4.1')) unless defined?(@association_finder_sql)
-      @association_finder_sql
+      ASSOCIATION_FINDER_SQL
     end
 
     def self.unscope_query_method_enabled?
-      @unscope_query_method = (::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new('4.1')) unless defined?(@unscope_query_method)
-      @unscope_query_method
+      UNSCOPE_QUERY_METHOD
     end
   end
 end

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -4,15 +4,18 @@ module Goldiloader
   module Compatibility
 
     def self.mass_assignment_security_enabled?
-      @mass_assignment_security_enabled ||= (::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity))
+      @mass_assignment_security_enabled = (::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity)) unless defined?(@mass_assignment_security_enabled)
+      @mass_assignment_security_enabled
     end
 
     def self.association_finder_sql_enabled?
-      @association_finder_sql ||= (::Gem::Version.new(::ActiveRecord::VERSION::STRING) < ::Gem::Version.new('4.1'))
+      @association_finder_sql = (::Gem::Version.new(::ActiveRecord::VERSION::STRING) < ::Gem::Version.new('4.1')) unless defined?(@association_finder_sql)
+      @association_finder_sql
     end
 
     def self.unscope_query_method_enabled?
-      @unscope_query_method ||= ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new('4.1')
+      @unscope_query_method = (::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new('4.1')) unless defined?(@unscope_query_method)
+      @unscope_query_method
     end
   end
 end

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -4,15 +4,15 @@ module Goldiloader
   module Compatibility
 
     def self.mass_assignment_security_enabled?
-      ::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity)
+      @mass_assignment_security_enabled ||= (::ActiveRecord::VERSION::MAJOR < 4 || defined?(::ActiveRecord::MassAssignmentSecurity))
     end
 
     def self.association_finder_sql_enabled?
-      ::Gem::Version.new(::ActiveRecord::VERSION::STRING) < ::Gem::Version.new('4.1')
+      @association_finder_sql ||= (::Gem::Version.new(::ActiveRecord::VERSION::STRING) < ::Gem::Version.new('4.1'))
     end
 
     def self.unscope_query_method_enabled?
-      ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new('4.1')
+      @unscope_query_method ||= ::Gem::Version.new(::ActiveRecord::VERSION::STRING) >= ::Gem::Version.new('4.1')
     end
   end
 end


### PR DESCRIPTION
Cache gem version checks within a variable; 

After running `ruby-prof` (https://github.com/ruby-prof/ruby-prof) on some code, I discovered there was some appreciable chunk of time in code being spent initializing ```Gem::Version``` objects and then comparing them. That lead me to this code here where I noticed these module methods were being called repeatedly. 

Primarily this seems to come from entry points such as https://github.com/salsify/goldiloader/blob/3a0f094300a5df32665e5ef4b2a4054bb8f46a5f/lib/goldiloader/active_record_patches.rb#L115 - since `load_target` is being called on collections to initialize objects, the number of ```Gem::Version``` objects created and comparisons done scale directly with the number of records returned.

Since the ActiveRecord version won't be changing once an application is started, we can simply cache this value in a variable as a simple boolean and return this. 