### PR TITLE
Gemspec: Release activerecord and activesupport constained dependency

### DIFF
--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir.glob('spec/**/*')
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 4.3'])
-  spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 4.3'])
+  spec.add_dependency 'activerecord', '>= 3.2'
+  spec.add_dependency 'activesupport', '>= 3.2'
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'database_cleaner', '>= 1.2'


### PR DESCRIPTION
Hey @jturkel 

Released gem from constrained dependency. Now support Activerecord and Activesupport version >= 3.2 instead of limiting it to Rails 4.3

Please review and merge.

Thanks.