### PR TITLE
Fix CollectionProxy#exists?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### 0.0.11 (unreleased)
 * Fix [issue 34](https://github.com/salsify/goldiloader/issues/34) - HABTM associations now honor 
   the auto_include option.
+* Fix [issue 39](https://github.com/salsify/goldiloader/issues/39) - `CollectionProxy#exists?` should return false 
+  for a new model's association with no values.
   
 ### 0.0.10
 * Fix [issue 13](https://github.com/salsify/goldiloader/issues/13) - Eager load associations with unscope

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mime-types', '~> 2'
 
   if RUBY_PLATFORM == 'java'
-    spec.add_development_dependency 'jdbc-sqlite3'
+    # jdbc-sqlite3 > 3.8 doesn't work with JRuby 1.7
+    spec.add_development_dependency 'jdbc-sqlite3', '~> 3.8.11'
     spec.add_development_dependency 'activerecord-jdbcsqlite3-adapter'
   else
     spec.add_development_dependency 'sqlite3'

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -168,6 +168,12 @@ ActiveRecord::Associations::CollectionProxy.class_eval do
     # We don't fully_load the association when arguments are passed to exists? since Rails always
     # pushes this query into the database without any caching (and it likely not a common
     # scenario worth optimizing).
-    args.empty? && @association.fully_load? ? size > 0 : super
+    if args.empty? && @association.fully_load?
+      size > 0
+    elsif Goldiloader::Compatibility::RAILS_3
+      scoped.exists?(*args)
+    else
+      scope.exists?(*args)
+    end
   end
 end

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -4,7 +4,8 @@ module Goldiloader
   module Compatibility
 
     ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING)
-    MASS_ASSIGNMENT_SECURITY = ACTIVE_RECORD_VERSION < ::Gem::Version.new('4') || defined?(::ActiveRecord::MassAssignmentSecurity)
+    RAILS_3 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('4')
+    MASS_ASSIGNMENT_SECURITY = RAILS_3 || defined?(::ActiveRecord::MassAssignmentSecurity)
     ASSOCIATION_FINDER_SQL = ACTIVE_RECORD_VERSION < ::Gem::Version.new('4.1')
     UNSCOPE_QUERY_METHOD = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('4.1')
     JOINS_EAGER_LOADABLE = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('4.2')

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -763,4 +763,25 @@ describe Goldiloader do
       end
     end
   end
+
+  describe "CollectionProxy#exists?" do
+    it "returns true for collections with values" do
+      expect(parent_tag1.children).to exist
+    end
+
+    it "returns false for collections without values" do
+      expect(child_tag1.children).not_to exist
+    end
+
+    if Goldiloader::Compatibility::RAILS_3
+      # Make sure we mimic the broken behavior of Rails 3
+      it "returns true for new models with empty associations" do
+        expect(Tag.new.children).to exist
+      end
+    else
+      it "returns false for new models with empty associations" do
+        expect(Tag.new.children).not_to exist
+      end
+    end
+  end
 end


### PR DESCRIPTION
`CollectionProxy#exists?` should return false for an unpersisted model's association with no values.

This fixes #39

@rlburkes - you're prime