### PR TITLE
Pass block to ActiveRecord::Relation#exec_queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### 0.0.12 (unreleased)
-* 
+* Fix [issue 42](https://github.com/salsify/goldiloader/issues/42) - inverse_of now work properly in Rails 5.x.
 
 ### 0.0.11
 * Fix [issue 34](https://github.com/salsify/goldiloader/issues/34) - HABTM associations now honor 

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -28,10 +28,10 @@ ActiveRecord::Base.send(:include, Goldiloader::AutoIncludableModel)
 
 ActiveRecord::Relation.class_eval do
 
-  def exec_queries_with_auto_include
-    return exec_queries_without_auto_include if loaded?
+  def exec_queries_with_auto_include(&block)
+    return exec_queries_without_auto_include(&block) if loaded?
 
-    models = exec_queries_without_auto_include
+    models = exec_queries_without_auto_include(&block)
     Goldiloader::AutoIncludeContext.register_models(models, eager_load_values)
     models
   end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -60,6 +60,7 @@ end
 
 class Blog < ActiveRecord::Base
   has_many :posts
+  has_many :posts_with_inverse_of, class_name: 'Post', inverse_of: :blog
   has_many :posts_without_auto_include, auto_include: false, class_name: 'Post'
   has_many :posts_fully_load, fully_load: true, class_name: 'Post'
 

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -198,6 +198,21 @@ describe Goldiloader do
     expect(users.second.posts).to eq Post.where(author_id: author2.id)
   end
 
+  it "sets inverse associations properly" do
+    blogs = Blog.order(:name).to_a
+
+    # Force the first blog's posts to load
+    blogs.first.posts_with_inverse_of.to_a
+
+    blogs.each do |blog|
+      expect(blog.association(:posts_with_inverse_of)).to be_loaded
+      blog.posts_with_inverse_of.each do |post|
+        expect(post.association(:blog)).to be_loaded
+        expect(post.blog.object_id).to eq(blog.object_id)
+      end
+    end
+  end
+
   it "only auto eager loads associations loaded through the same path" do
     root_tags = Tag.where(parent_id: nil).order(:name).to_a
     root_tags.first.children.to_a


### PR DESCRIPTION
Pass block to ActiveRecord::Relation#exec_queries to fix inverse_of in Rails 5.x. Fixes #42.

@rlburkes - you're prime