### PR TITLE
Rails 5.1 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,37 @@ env:
   - RAILS_VERSION="~> 3.2.22.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
   - RAILS_VERSION="~> 4.0.13" JRUBY_OPTS="$JRUBY_OPTS --debug"
   - RAILS_VERSION="~> 4.1.16" JRUBY_OPTS="$JRUBY_OPTS --debug"
-  - RAILS_VERSION="~> 4.2.7.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
-  - RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
+  - RAILS_VERSION="~> 4.2.8" JRUBY_OPTS="$JRUBY_OPTS --debug"
+  - RAILS_VERSION="~> 5.0.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
+  - RAILS_VERSION="~> 5.1.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
+  - RAILS_VERSION="~> 5.2.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
 rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.6
+  - 2.2.7
   - 2.3.3
   - jruby-19mode
   - jruby-9.1.7.0
 matrix:
   exclude:
     - rvm: 1.9.3
-      env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
+      env: RAILS_VERSION="~> 5.0.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
     - rvm: 2.0.0
-      env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
+      env: RAILS_VERSION="~> 5.0.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
     - rvm: 2.1.10
-      env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
+      env: RAILS_VERSION="~> 5.0.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
     - rvm: jruby-19mode
-      env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
+      env: RAILS_VERSION="~> 5.0.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
     - rvm: jruby-9.1.7.0
-      env: RAILS_VERSION="~> 5.0.1" JRUBY_OPTS="$JRUBY_OPTS --debug"
+      env: RAILS_VERSION="~> 5.0.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
+    - rvm: 1.9.3
+      env: RAILS_VERSION="~> 5.1.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
+    - rvm: 2.0.0
+      env: RAILS_VERSION="~> 5.1.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
+    - rvm: 2.1.10
+      env: RAILS_VERSION="~> 5.1.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
+    - rvm: jruby-19mode
+      env: RAILS_VERSION="~> 5.1.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
+    - rvm: jruby-9.1.7.0
+      env: RAILS_VERSION="~> 5.1.0" JRUBY_OPTS="$JRUBY_OPTS --debug"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - RAILS_VERSION="~> 4.2.8" JRUBY_OPTS="$JRUBY_OPTS --debug"
   - RAILS_VERSION="~> 5.0.2" JRUBY_OPTS="$JRUBY_OPTS --debug"
   - RAILS_VERSION="~> 5.1.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
-  - RAILS_VERSION="~> 5.2.0" JRUBY_OPTS="$JRUBY_OPTS --debug"
 rvm:
   - 1.9.3
   - 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### 0.0.12 (unreleased)
-* 
+* Rails 5.1 support
 
 ### 0.0.11
 * Fix [issue 34](https://github.com/salsify/goldiloader/issues/34) - HABTM associations now honor 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Goldiloader detects associations with any of these options and disables automati
 
 ## Status
 
-This gem is tested with Rails 3.2, 4.0, 4.1, 4.2, and 5.0 using MRI 1.9.3, 2.0, 2.1, 2.2, 2.3, JRuby 1.7 in 1.9 mode, and JRuby 9000. 
+This gem is tested with Rails 3.2, 4.0, 4.1, 4.2, 5.0 and 5.1 using MRI 1.9.3, 2.0, 2.1, 2.2, 2.3, JRuby 1.7 in 1.9 mode, and JRuby 9000. 
 
 Let us know if you find any issues or have any other feedback. 
 

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir.glob('spec/**/*')
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.1'])
-  spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.1'])
+  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.2'])
+  spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.2'])
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'database_cleaner', '>= 1.2'


### PR DESCRIPTION
This PR add Goldiloader support for Rails 5.1. The only change of interest was fallout from rails/rails#26200 which removed methods affected by the `fully_load` setting from `ActiveRecord::Associations::CollectionAssociation` in favor of methods in `ActiveRecord::Associations::CollectionProxy`. Fortunately we can just override the `ActiveRecord::Associations::CollectionAssociation#find_from_target?` method to do the right thing.

The conditionals based on Rails versions continue to be a mess. At some point I'll cut a 1.0 release and then start working on a 2.0 release the drops support for older versions of Rails (likely 3.2, 4.0 and 4.1).

@rlburkes - you're prime 