### PR TITLE
Drop support for old versions of Ruby/Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,36 +4,22 @@ env:
   global:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
   matrix:
-    - RAILS_VERSION="~> 3.2.22.2"
-    - RAILS_VERSION="~> 4.0.13"
-    - RAILS_VERSION="~> 4.1.16"
-    - RAILS_VERSION="~> 4.2.7.1"
+    - RAILS_VERSION="~> 4.2.8"
     - RAILS_VERSION="~> 5.0.2"
     - RAILS_VERSION="~> 5.1.0"
 rvm:
-  - 1.9.3
-  - 2.0.0
   - 2.1.10
   - 2.2.7
-  - 2.3.3
-  - jruby-19mode
+  - 2.3.4
   - jruby-9.1.7.0
 matrix:
   exclude:
-    - rvm: 1.9.3
-      env: RAILS_VERSION="~> 5.0.2"
-    - rvm: 2.0.0
-      env: RAILS_VERSION="~> 5.0.2"
     - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.0.2"
     - rvm: jruby-19mode
       env: RAILS_VERSION="~> 5.0.2"
     - rvm: jruby-9.1.7.0
       env: RAILS_VERSION="~> 5.0.2"
-    - rvm: 1.9.3
-      env: RAILS_VERSION="~> 5.1.0"
-    - rvm: 2.0.0
-      env: RAILS_VERSION="~> 5.1.0"
     - rvm: 2.1.10
       env: RAILS_VERSION="~> 5.1.0"
     - rvm: jruby-19mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+### 2.0.0 (unreleased)
+* Rails 5.1 support.
+* Drop Rails 3.2, 4.0 and 4.1 and Ruby 1.9 and 2.0 support.
+
 ### 0.0.12 (unreleased)
-* Rails 5.1 support
 * Fix [issue 42](https://github.com/salsify/goldiloader/issues/42) - inverse_of now work properly in Rails 5.x.
 
 ### 0.0.11

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Wouldn't it be awesome if ActiveRecord didn't make you think about eager loading and it just did the "right" thing by default? With Goldiloader it can!
 
-**This branch only supports Rails 4.2+ with Ruby 2.1+. For older versions of Rails/Ruby use [1-0-stable](https://github.com/salsify/goldiloader/blob/1-x-stable/README.md).**
+**This branch only supports Rails 4.2+ with Ruby 2.1+. For older versions of Rails/Ruby use [1-x-stable](https://github.com/salsify/goldiloader/blob/1-x-stable/README.md).**
 
 Consider the following models:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 Wouldn't it be awesome if ActiveRecord didn't make you think about eager loading and it just did the "right" thing by default? With Goldiloader it can!
 
+**This branch only supports Rails 4.2+ with Ruby 2.1+. For older versions of Rails/Ruby use [1-0-stable](https://github.com/salsify/goldiloader/blob/1-0-stable/README.md).**
+
 Consider the following models:
 
 ```ruby
@@ -169,7 +171,7 @@ Goldiloader detects associations with any of these options and disables automati
 
 ## Status
 
-This gem is tested with Rails 3.2, 4.0, 4.1, 4.2, 5.0 and 5.1 using MRI 1.9.3, 2.0, 2.1, 2.2, 2.3, JRuby 1.7 in 1.9 mode, and JRuby 9000. 
+This gem is tested with Rails 4.2, 5.0 and 5.1 using MRI 2.1, 2.2, and 2.3 and JRuby 9000. 
 
 Let us know if you find any issues or have any other feedback. 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Wouldn't it be awesome if ActiveRecord didn't make you think about eager loading and it just did the "right" thing by default? With Goldiloader it can!
 
-**This branch only supports Rails 4.2+ with Ruby 2.1+. For older versions of Rails/Ruby use [1-0-stable](https://github.com/salsify/goldiloader/blob/1-0-stable/README.md).**
+**This branch only supports Rails 4.2+ with Ruby 2.1+. For older versions of Rails/Ruby use [1-0-stable](https://github.com/salsify/goldiloader/blob/1-x-stable/README.md).**
 
 Consider the following models:
 

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files lib Readme.md LICENSE.txt`.split($/)
 
+  spec.required_ruby_version = '>= 2.1'
+
   spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 4.2', '< 5.2'])
   spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 4.2', '< 5.2'])
 

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -15,20 +15,18 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files lib Readme.md LICENSE.txt`.split($/)
 
-  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.2'])
-  spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 3.2', '< 5.2'])
+  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', ['>= 4.2', '< 5.2'])
+  spec.add_dependency 'activesupport', ENV.fetch('RAILS_VERSION', ['>= 4.2', '< 5.2'])
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'database_cleaner', '>= 1.2'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'simplecov', '~> 0.7.1'
-  # mime-type 3 requires Ruby >= 2.0
-  spec.add_development_dependency 'mime-types', '~> 2'
+  spec.add_development_dependency 'mime-types'
 
   if RUBY_PLATFORM == 'java'
-    # jdbc-sqlite3 > 3.8 doesn't work with JRuby 1.7
-    spec.add_development_dependency 'jdbc-sqlite3', '~> 3.8.11'
+    spec.add_development_dependency 'jdbc-sqlite3'
     spec.add_development_dependency 'activerecord-jdbcsqlite3-adapter'
   else
     spec.add_development_dependency 'sqlite3'

--- a/lib/goldiloader/association_info.rb
+++ b/lib/goldiloader/association_info.rb
@@ -7,119 +7,30 @@ module Goldiloader
       @association = association
     end
 
-    def finder_sql?
-      Goldiloader::Compatibility.association_finder_sql_enabled? &&
-        association_options[:finder_sql].present?
+    delegate :association_scope, :reflection, to: :@association
+
+    def offset?
+      association_scope && association_scope.offset_value.present?
     end
 
-    if ActiveRecord::VERSION::MAJOR >= 4
-      delegate :association_scope, :reflection, to: :@association
+    def limit?
+      association_scope && association_scope.limit_value.present?
+    end
 
-      def read_only?
-        association_scope && association_scope.readonly_value.present?
-      end
-
-      def offset?
-        association_scope && association_scope.offset_value.present?
-      end
-
-      def limit?
-        association_scope && association_scope.limit_value.present?
-      end
-
-      def from?
-        if ActiveRecord::VERSION::MAJOR >= 5
-          association_scope && association_scope.from_clause.present?
-        else
-          association_scope && association_scope.from_value.present?
-        end
-      end
-
-      def group?
-        association_scope && association_scope.group_values.present?
-      end
-
-      def joins?
-        return false unless association_scope
-
-        num_joins = association_scope.joins_values.size
-        if ActiveRecord::VERSION::MAJOR >= 5
-          num_joins += association_scope.left_joins_values.size + association_scope.left_outer_joins.size
-        end
-        # Yuck - Through associations will always have a join for *each* 'through' table
-        num_joins - num_through_joins > 0
-      end
-
-      def uniq?
-        association_scope && association_scope.uniq_value
-      end
-
-      def instance_dependent?
-        reflection.scope.present? && reflection.scope.arity > 0
-      end
-
-      def unscope?
-        Goldiloader::Compatibility.unscope_query_method_enabled? &&
-            association_scope &&
-            association_scope.unscope_values.present?
-      end
-
-      private
-
-      def num_through_joins
-        association = @association
-        count = 0
-        while association.is_a?(ActiveRecord::Associations::ThroughAssociation)
-          count += 1
-          association = association.owner.association(association.through_reflection.name)
-        end
-        count
-      end
-    else
-      def read_only?
-        association_options[:readonly].present?
-      end
-
-      def offset?
-        association_options[:offset].present?
-      end
-
-      def limit?
-        association_options[:limit].present?
-      end
-
-      def from?
-        false
-      end
-
-      def group?
-        association_options[:group].present?
-      end
-
-      def joins?
-        # Rails 3 didn't support joins for associations
-        false
-      end
-
-      def uniq?
-        association_options[:uniq]
-      end
-
-      def instance_dependent?
-        # Rails 3 didn't support this
-        false
-      end
-
-      def unscope?
-        # Rails 3 didn't support this
-        false
+    def from?
+      if ActiveRecord::VERSION::MAJOR >= 5
+        association_scope && association_scope.from_clause.present?
+      else
+        association_scope && association_scope.from_value.present?
       end
     end
 
-    private
+    def group?
+      association_scope && association_scope.group_values.present?
+    end
 
-    def association_options
-      @association.options
+    def instance_dependent?
+      reflection.scope.present? && reflection.scope.arity > 0
     end
   end
 end

--- a/lib/goldiloader/association_loader.rb
+++ b/lib/goldiloader/association_loader.rb
@@ -10,36 +10,12 @@ module Goldiloader
       end
 
       eager_load(models, association_name)
-      
-      # Workaround Rails #15853 for Rails < 4.2.0 by setting models read only
-      if read_only?(models, association_name)
-        associated_models = associated_models(models, association_name)
-        mark_read_only(associated_models)
-      end
     end
 
     private
 
     def eager_load(models, association_name)
-      if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new('4.1')
-        ::ActiveRecord::Associations::Preloader.new.preload(models, [association_name])
-      else
-        ::ActiveRecord::Associations::Preloader.new(models, [association_name]).run
-      end
-    end
-
-    def mark_read_only(models)
-      models.each(&:readonly!)
-    end
-
-    def read_only?(models, association_name)
-      model = first_model_with_association(models, association_name)
-      if model.nil?
-        false
-      else
-        association_info = AssociationInfo.new(model.association(association_name))
-        association_info.read_only?
-      end
+      ::ActiveRecord::Associations::Preloader.new.preload(models, [association_name])
     end
 
     def first_model_with_association(models, association_name)

--- a/lib/goldiloader/association_options.rb
+++ b/lib/goldiloader/association_options.rb
@@ -20,30 +20,12 @@ module Goldiloader
     def register
       if ::ActiveRecord::VERSION::MAJOR >= 5
         ActiveRecord::Associations::Builder::Association.extensions << AssociationBuilderExtension
-      elsif ::ActiveRecord::VERSION::MAJOR >= 4
-        ActiveRecord::Associations::Builder::Association.valid_options.concat(OPTIONS)
       else
-        # Each subclass of CollectionAssociation will have its own copy of valid_options so we need
-        # to register the valid option for each one.
-        collection_association_classes.each do |assoc_class|
-          assoc_class.valid_options.concat(OPTIONS)
-        end
+        ActiveRecord::Associations::Builder::Association.valid_options.concat(OPTIONS)
       end
     end
 
     private
-
-    def collection_association_classes
-      # Association.descendants doesn't work well with lazy classloading :(
-      [
-        ActiveRecord::Associations::Builder::Association,
-        ActiveRecord::Associations::Builder::BelongsTo,
-        ActiveRecord::Associations::Builder::HasAndBelongsToMany,
-        ActiveRecord::Associations::Builder::HasMany,
-        ActiveRecord::Associations::Builder::HasOne,
-        ActiveRecord::Associations::Builder::SingularAssociation
-      ]
-    end
   end
 end
 

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -2,38 +2,7 @@
 
 module Goldiloader
   module Compatibility
-
     ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING)
-    RAILS_3 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('4')
-    MASS_ASSIGNMENT_SECURITY = RAILS_3 || defined?(::ActiveRecord::MassAssignmentSecurity)
-    ASSOCIATION_FINDER_SQL = ACTIVE_RECORD_VERSION < ::Gem::Version.new('4.1')
-    UNSCOPE_QUERY_METHOD = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('4.1')
-    JOINS_EAGER_LOADABLE = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('4.2')
-    UNSCOPED_EAGER_LOADABLE = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('4.1.9')
-
-    def self.mass_assignment_security_enabled?
-      MASS_ASSIGNMENT_SECURITY
-    end
-
-    def self.association_finder_sql_enabled?
-      ASSOCIATION_FINDER_SQL
-    end
-
-    def self.unscope_query_method_enabled?
-      UNSCOPE_QUERY_METHOD
-    end
-
-    def self.joins_eager_loadable?
-      # Associations with joins were not eager loadable prior to Rails 4.2 due to
-      # https://github.com/rails/rails/pull/17678
-      JOINS_EAGER_LOADABLE
-    end
-
-    def self.unscoped_eager_loadable?
-      # Unscoped associations weren't properly eager loaded until after Rails 4.1.9.
-      # See https://github.com/rails/rails/issues/11036.
-      UNSCOPED_EAGER_LOADABLE
-    end
 
     # Copied from Rails since it is deprecated in Rails 5.0. Switch to using
     # Module#prepend when we drop Ruby 1.9 support.

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -47,10 +47,6 @@ class Tag < ActiveRecord::Base
   belongs_to :owner, polymorphic: true
   has_many :post_tags
   has_many :posts, through: :post_tags
-
-  if Goldiloader::Compatibility.mass_assignment_security_enabled?
-    attr_accessible :name
-  end
 end
 
 class PostTag < ActiveRecord::Base
@@ -64,38 +60,20 @@ class Blog < ActiveRecord::Base
   has_many :posts_without_auto_include, auto_include: false, class_name: 'Post'
   has_many :posts_fully_load, fully_load: true, class_name: 'Post'
 
-  if ActiveRecord::VERSION::MAJOR >= 4
-    has_many :read_only_posts, -> { readonly }, class_name: 'Post'
-    has_many :limited_posts, -> { limit(2) }, class_name: 'Post'
-    has_many :grouped_posts, -> { group(:blog_id) }, class_name: 'Post'
-    has_many :offset_posts, -> { offset(2) }, class_name: 'Post'
-    has_many :from_posts, -> { from('(select distinct blog_id from posts) as posts') }, class_name: 'Post'
-    has_many :instance_dependent_posts, ->(instance) { Post.where(blog_id: instance.id) }, class_name: 'Post'
+  has_many :read_only_posts, -> { readonly }, class_name: 'Post'
+  has_many :limited_posts, -> { limit(2) }, class_name: 'Post'
+  has_many :grouped_posts, -> { group(:blog_id) }, class_name: 'Post'
+  has_many :offset_posts, -> { offset(2) }, class_name: 'Post'
+  has_many :from_posts, -> { from('(select distinct blog_id from posts) as posts') }, class_name: 'Post'
+  has_many :instance_dependent_posts, ->(instance) { Post.where(blog_id: instance.id) }, class_name: 'Post'
 
-    has_many :posts_ordered_by_author, -> { joins(:author).order('users.name') }, class_name: 'Post'
+  has_many :posts_ordered_by_author, -> { joins(:author).order('users.name') }, class_name: 'Post'
 
-    has_many :authors_with_join, -> { joins(:address).order('addresses.city') }, through: :posts, source: :author
-  else
-    has_many :read_only_posts, readonly: true, class_name: 'Post'
-    has_many :limited_posts, limit: 2, class_name: 'Post'
-    has_many :grouped_posts, group: :blog_id, class_name: 'Post'
-    has_many :offset_posts, offset: 2, class_name: 'Post'
-
-    has_many :posts_ordered_by_author, include: :author, order: 'users.name', class_name: 'Post'
-  end
-
-  if Goldiloader::Compatibility.association_finder_sql_enabled?
-    has_many :finder_sql_posts, finder_sql: Proc.new { "select distinct blog_id from posts where blog_id = #{self.id}" },
-             class_name: 'Post'
-  end
+  has_many :authors_with_join, -> { joins(:address).order('addresses.city') }, through: :posts, source: :author
 
   has_many :posts_overridden, class_name: 'Post'
   has_many :authors, through: :posts
   has_many :addresses, through: :authors
-
-  if Goldiloader::Compatibility.mass_assignment_security_enabled?
-    attr_accessible :name
-  end
 
   def posts_overridden
     'boom'
@@ -111,23 +89,11 @@ class Post < ActiveRecord::Base
 
   belongs_to :owner, polymorphic: true
 
-  if ActiveRecord::VERSION::MAJOR >= 4
-    has_many :unique_tags, -> { distinct }, through: :post_tags, source: :tag, class_name: 'Tag'
-  else
-    has_many :unique_tags, through: :post_tags, source: :tag, uniq: true, class_name: 'Tag'
-  end
-
-  if ActiveRecord::VERSION::MAJOR < 4
-    has_and_belongs_to_many :unique_tags_has_and_belongs, join_table: :post_tags, class_name: 'Tag', uniq: true
-  end
+  has_many :unique_tags, -> { distinct }, through: :post_tags, source: :tag, class_name: 'Tag'
 
   has_and_belongs_to_many :tags_without_auto_include, join_table: :post_tags, class_name: 'Tag', auto_include: false
 
   after_destroy :after_post_destroy
-
-  if Goldiloader::Compatibility.mass_assignment_security_enabled?
-    attr_accessible :title
-  end
 
   def after_post_destroy
     # Hook for tests
@@ -140,37 +106,19 @@ class User < ActiveRecord::Base
   has_one :address
   has_one :address_without_auto_include, auto_include: false, class_name: 'Address'
 
-  if Goldiloader::Compatibility.unscope_query_method_enabled?
-    has_one :scoped_address_with_default_scope_remove, -> { unscope(where: :city) }, class_name: 'ScopedAddress'
-  end
-
-  if Goldiloader::Compatibility.mass_assignment_security_enabled?
-    attr_accessible :name
-  end
+  has_one :scoped_address_with_default_scope_remove, -> { unscope(where: :city) }, class_name: 'ScopedAddress'
 end
 
 class Address < ActiveRecord::Base
   belongs_to :user
-
-  if Goldiloader::Compatibility.mass_assignment_security_enabled?
-    attr_accessible :city
-  end
 end
 
 class ScopedAddress < ActiveRecord::Base
   self.table_name = 'addresses'
   default_scope { where(city: ['Philadelphia'])}
   belongs_to :user
-
-  if Goldiloader::Compatibility.mass_assignment_security_enabled?
-    attr_accessible :city
-  end
 end
 
 class Group < ActiveRecord::Base
   has_many :tags, as: :owner
-
-  if Goldiloader::Compatibility.mass_assignment_security_enabled?
-    attr_accessible :name
-  end
 end


### PR DESCRIPTION
This PR drops support for Rails 3.2/4.0/4.1 and Ruby 1.9/2.0. This allowed us to drop lots of code and conditionals needed to support old versions of Rails. I'm going to switch the monkey patching over to use `Module#prepend` in another PR.

@tjwp - you're prime