### PR TITLE
Add auto_include query scope method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### 2.0.0 (unreleased)
+* Add `auto_include` query scope method.
+* Remove `auto_include` association option in favor of using the `auto_include` query scope method.
 * Add Rails 5.1 support.
 * Drop Rails 3.2, 4.0 and 4.1 and Ruby 1.9 and 2.0 support.
 * Change ActiveRecord monkey patching to use `Module#prepend` instead of `alias_method_chain`.

--- a/README.md
+++ b/README.md
@@ -72,19 +72,25 @@ Or install it yourself as:
 
 By default all associations will be automatically eager loaded when they are first accessed so hopefully most use cases should require no additional configuration. Note you're still free to explicitly eager load associations via `eager_load`, `includes`, or `preload`.
 
-### Association Options
+### Disabling Automatic Eager Loading
 
-Goldiloader supports a few options on ActiveRecord associations to customize its behavior.
+You can disable automatic eager loading with `auto_include` query scope method:
 
-#### auto_include
+```ruby
+Blog.order(:name).auto_include(false)
+```
 
-You can disable automatic eager loading on specific associations with the `auto_include` option:
+This can also be used to disable automatic eager loading for associations:
 
 ```ruby
 class Blog < ActiveRecord::Base
-  has_many :posts, auto_include: false
+  has_many :posts, -> { auto_include(false) }
 end
 ```
+
+### Association Options
+
+Goldiloader supports a few options on ActiveRecord associations to customize its behavior.
 
 #### fully_load
 
@@ -164,10 +170,25 @@ Associations with any of the following options cannot be eager loaded:
 * `finder_sql`
 * `group` (due to a Rails bug)
 * `from` (due to a Rails bug)
-* `joins` (only Rails 4.0/4.1 - due to a Rails bug)
-* `uniq` (only Rails 3.2 - due to a Rails bug)
 
 Goldiloader detects associations with any of these options and disables automatic eager loading on them.
+
+## Upgrading
+
+### From 0.x, 1.x
+
+The `auto_include` association option has been removed in favor of the `auto_include` query scope method. 
+Associations that specify this option must migrate to use the query scope method:
+
+```ruby
+class Blog < ActiveRecord::Base
+  # Old syntax
+  has_many :posts, auto_include: false
+  
+  # New syntax
+  has_many :posts, -> { auto_include(false) }
+end
+```
 
 ## Status
 

--- a/lib/goldiloader/association_info.rb
+++ b/lib/goldiloader/association_info.rb
@@ -17,6 +17,10 @@ module Goldiloader
       association_scope && association_scope.limit_value.present?
     end
 
+    def auto_include?
+      association_scope.nil? || association_scope.auto_include_value
+    end
+
     def from?
       if ActiveRecord::VERSION::MAJOR >= 5
         association_scope && association_scope.from_clause.present?

--- a/lib/goldiloader/association_options.rb
+++ b/lib/goldiloader/association_options.rb
@@ -4,7 +4,7 @@ module Goldiloader
   module AssociationOptions
     extend self
 
-    OPTIONS = [:auto_include, :fully_load].freeze
+    OPTIONS = [:fully_load].freeze
 
     # This is only used in Rails 5+
     module AssociationBuilderExtension

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -3,5 +3,13 @@
 module Goldiloader
   module Compatibility
     ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING)
+
+    def self.rails_4?
+      ::ActiveRecord::VERSION::MAJOR == 4
+    end
+
+    def self.rails_5_0?
+      ::ActiveRecord::VERSION::MAJOR == 5 && ::ActiveRecord::VERSION::MINOR == 0
+    end
   end
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -57,7 +57,7 @@ end
 class Blog < ActiveRecord::Base
   has_many :posts
   has_many :posts_with_inverse_of, class_name: 'Post', inverse_of: :blog
-  has_many :posts_without_auto_include, auto_include: false, class_name: 'Post'
+  has_many :posts_without_auto_include, -> { auto_include(false) }, class_name: 'Post'
   has_many :posts_fully_load, fully_load: true, class_name: 'Post'
 
   has_many :read_only_posts, -> { readonly }, class_name: 'Post'
@@ -82,7 +82,7 @@ end
 
 class Post < ActiveRecord::Base
   belongs_to :blog
-  belongs_to :blog_without_auto_include, auto_include: false, class_name: 'Blog', foreign_key: :blog_id
+  belongs_to :blog_without_auto_include, -> { auto_include(false) }, class_name: 'Blog', foreign_key: :blog_id
   belongs_to :author, class_name: 'User'
   has_many :post_tags
   has_many :tags, through: :post_tags
@@ -91,7 +91,7 @@ class Post < ActiveRecord::Base
 
   has_many :unique_tags, -> { distinct }, through: :post_tags, source: :tag, class_name: 'Tag'
 
-  has_and_belongs_to_many :tags_without_auto_include, join_table: :post_tags, class_name: 'Tag', auto_include: false
+  has_and_belongs_to_many :tags_without_auto_include, -> { auto_include(false) }, join_table: :post_tags, class_name: 'Tag'
 
   after_destroy :after_post_destroy
 
@@ -104,7 +104,7 @@ class User < ActiveRecord::Base
   has_many :posts, foreign_key: :author_id
   has_many :tags, as: :owner
   has_one :address
-  has_one :address_without_auto_include, auto_include: false, class_name: 'Address'
+  has_one :address_without_auto_include, -> { auto_include(false) }, class_name: 'Address'
 
   has_one :scoped_address_with_default_scope_remove, -> { unscope(where: :city) }, class_name: 'ScopedAddress'
 end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -652,7 +652,19 @@ describe Goldiloader do
 
   context "with auto_include disabled" do
 
-    it "doesn't auto eager load has_many associations" do
+    it "doesn't auto eager load associations when the query disables auto include" do
+      blogs = Blog.auto_include(false).order(:name).to_a
+
+      # Force the first blogs first post to load
+      posts = blogs.first.posts.to_a
+      expect(posts).to match_array Post.where(blog_id: blogs.first.id)
+
+      blogs.drop(1).each do |blog|
+        expect(blog.association(:posts)).to_not be_loaded
+      end
+    end
+
+    it "doesn't auto eager load has_many associations with auto include disabled" do
       blogs = Blog.order(:name).to_a
 
       # Force the first blogs first post to load
@@ -664,7 +676,7 @@ describe Goldiloader do
       end
     end
 
-    it "doesn't auto eager load has_one associations" do
+    it "doesn't auto eager load has_one associations with auto include disabled" do
       users = User.order(:name).to_a
 
       # Force the first user's address to load
@@ -677,7 +689,7 @@ describe Goldiloader do
       end
     end
 
-    it "doesn't auto eager load belongs_to associations" do
+    it "doesn't auto eager load belongs_to associations with auto include disabled" do
       posts = Post.order(:title).to_a
       # Force the first post's blog to load
       post = posts.first
@@ -689,7 +701,7 @@ describe Goldiloader do
       end
     end
 
-    it "doesn't auto eager load has_and_belongs_to_many associations" do
+    it "doesn't auto eager load has_and_belongs_to_many associations with auto include disabled" do
       posts = Post.all.to_a
 
       # Force the first post's tags to load


### PR DESCRIPTION
This PR adds an `auto_include` query scope method to disable automatic eager loading for individual queries e.g.

```ruby
Blog.order(:name).auto_include(false)
```

It also removes the `auto_include` association option in favor of using the query scope method (which we can do now that we dropped Rails 3.2 support). The migration path will be:

```ruby
class Blog < ActiveRecord::Base
  # Old syntax
  has_many :posts, auto_include: false

  # New syntax
  has_many :posts, -> { auto_include(false) }
end
```

@tjwp - you're prime