### PR TITLE
Rails 5.2 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ gemfile:
   - gemfiles/rails_5.2.gemfile
 rvm:
   - 2.1.10
-  - 2.2.8
-  - 2.3.6
-  - 2.4.3
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
   - jruby-9.1.13.0
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ gemfile:
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile
+  - gemfiles/rails_5.2.gemfile
 rvm:
   - 2.1.10
   - 2.2.8
@@ -19,3 +20,5 @@ matrix:
       gemfile: gemfiles/rails_5.0.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails_5.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - 2.2.10
   - 2.3.7
   - 2.4.4
-  - jruby-9.1.13.0
+  - jruby-9.1.16.0
 matrix:
   exclude:
     - rvm: 2.1.10
@@ -21,4 +21,6 @@ matrix:
     - rvm: 2.1.10
       gemfile: gemfiles/rails_5.1.gemfile
     - rvm: 2.1.10
+      gemfile: gemfiles/rails_5.2.gemfile
+    - rvm: jruby-9.1.16.0
       gemfile: gemfiles/rails_5.2.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -12,6 +12,11 @@ appraise 'rails-5.0' do
 end
 
 appraise 'rails-5.1' do
-  gem 'activerecord', '5.1.4'
-  gem 'activesupport', '5.1.4'
+  gem 'activerecord', '5.1.5'
+  gem 'activesupport', '5.1.5'
+end
+
+appraise 'rails-5.2' do
+  gem 'activerecord', '5.2.0.rc2 '
+  gem 'activesupport', '5.2.0.rc2 '
 end

--- a/Appraisals
+++ b/Appraisals
@@ -7,16 +7,16 @@ appraise 'rails-4.2' do
 end
 
 appraise 'rails-5.0' do
-  gem 'activerecord', '5.0.6'
-  gem 'activesupport', '5.0.6'
+  gem 'activerecord', '5.0.7'
+  gem 'activesupport', '5.0.7'
 end
 
 appraise 'rails-5.1' do
-  gem 'activerecord', '5.1.5'
-  gem 'activesupport', '5.1.5'
+  gem 'activerecord', '5.1.6'
+  gem 'activesupport', '5.1.6'
 end
 
 appraise 'rails-5.2' do
-  gem 'activerecord', '5.2.0.rc2 '
-  gem 'activesupport', '5.2.0.rc2 '
+  gem 'activerecord', '5.2.0 '
+  gem 'activesupport', '5.2.0 '
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.1.0
+* Rails 5.2 support.
+
 ### 2.0.1
 * No code changes. Fix bad deploy.
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ end
 
 ## Status
 
-This gem is tested with Rails 4.2, 5.0 and 5.1 using MRI 2.1, 2.2, 2.3 and 2.4 and JRuby 9000. 
+This gem is tested with Rails 4.2, 5.0, 5.1 and 5.2 using MRI 2.1, 2.2, 2.3 and 2.4 and JRuby 9000. 
 
 Let us know if you find any issues or have any other feedback. 
 

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.0.6"
-gem "activesupport", "5.0.6"
+gem "activerecord", "5.0.7"
+gem "activesupport", "5.0.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.1.5"
-gem "activesupport", "5.1.5"
+gem "activerecord", "5.1.6"
+gem "activesupport", "5.1.6"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.2.0.rc2 "
-gem "activesupport", "5.2.0.rc2 "
+gem "activerecord", "5.2.0 "
+gem "activesupport", "5.2.0 "
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.1.5"
-gem "activesupport", "5.1.5"
+gem "activerecord", "5.2.0.rc2 "
+gem "activesupport", "5.2.0.rc2 "
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency 'activerecord', '>= 4.2', '< 5.2'
-  spec.add_dependency 'activesupport', '>= 4.2', '< 5.2'
+  spec.add_dependency 'activerecord', '>= 4.2', '< 5.3'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 5.3'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'coveralls'

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -103,7 +103,8 @@ module Goldiloader
         !association_info.group? &&
         !association_info.from? &&
         !association_info.instance_dependent? &&
-        association_info.auto_include?
+        association_info.auto_include? &&
+        (!owner.destroyed? || ::Goldiloader::Compatibility.destroyed_model_associations_eager_loadable?)
     end
 
     def load_with_auto_include

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -3,6 +3,7 @@
 module Goldiloader
   module Compatibility
     ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING)
+    PRE_RAILS_5_2 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.2.0')
 
     def self.rails_4?
       ::ActiveRecord::VERSION::MAJOR == 4
@@ -10,6 +11,11 @@ module Goldiloader
 
     def self.rails_5_0?
       ::ActiveRecord::VERSION::MAJOR == 5 && ::ActiveRecord::VERSION::MINOR == 0
+    end
+
+    # See https://github.com/rails/rails/pull/32375
+    def self.destroyed_model_associations_eager_loadable?
+      PRE_RAILS_5_2
     end
   end
 end

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 
 module Goldiloader
-  VERSION = '2.0.1'.freeze
+  VERSION = '2.1.0'.freeze
 end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -508,8 +508,14 @@ describe Goldiloader do
       expect(@blog_after_destroy).to eq blog1
     end
 
-    it "auto eager loads the associaton on other models" do
-      expect(other_post.association(:blog)).to be_loaded
+    if ::Goldiloader::Compatibility.destroyed_model_associations_eager_loadable?
+      it "auto eager loads the associations on other models" do
+        expect(other_post.association(:blog)).to be_loaded
+      end
+    else
+      it "doesn't auto eager loads associations on other models" do
+        expect(other_post.association(:blog)).not_to be_loaded
+      end
     end
   end
 


### PR DESCRIPTION
The only interesting change was a workaround for https://github.com/rails/rails/pull/32375 which prevents automatic eagerloading from working on destroyed models. Also note activerecord-jdbc-adapter doesn't yet support Rails 5.2 so I had to disable those tests.

Fixes #63.

@will89 - you're prime