### PR TITLE
Link to referenced Rails bug in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Associations with any of the following options cannot be eager loaded:
 * `limit`
 * `offset`
 * `finder_sql`
-* `group` (due to a Rails bug)
+* `group` (due to a [Rails bug](https://github.com/rails/rails/issues/15854))
 * `from` (due to a Rails bug)
 
 Goldiloader detects associations with any of these options and disables automatic eager loading on them.


### PR DESCRIPTION
Also wondering if "from" can be removed from the list for Rails 5.2+ due to [this fix](https://github.com/rails/rails/pull/29413)