### PR TITLE
Enable eager loading of associations with a from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.1.1
+* Enable eager loading of associations with a `from` in Rails 5.0.x >= 5.0.7 and Rails >= 5.1.5 because
+  the underlying Rails bug has been fixed.
+  
 ### 2.1.0
 * Rails 5.2 support.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Associations with any of the following options cannot be eager loaded:
 * `offset`
 * `finder_sql`
 * `group` (due to a [Rails bug](https://github.com/rails/rails/issues/15854))
-* `from` (due to a Rails bug)
+* `from` (only applies to Rails < 5.0.7 and Rails 5.1.x < 5.1.5 due to a Rails bug)
 
 Goldiloader detects associations with any of these options and disables automatic eager loading on them.
 

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -101,7 +101,7 @@ module Goldiloader
       !association_info.limit? &&
         !association_info.offset? &&
         !association_info.group? &&
-        !association_info.from? &&
+        (!association_info.from? || ::Goldiloader::Compatibility.from_eager_loadable?) &&
         !association_info.instance_dependent? &&
         association_info.auto_include? &&
         (!owner.destroyed? || ::Goldiloader::Compatibility.destroyed_model_associations_eager_loadable?)

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -4,6 +4,10 @@ module Goldiloader
   module Compatibility
     ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING)
     PRE_RAILS_5_2 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.2.0')
+    POST_RAILS_5_1_4 = ACTIVE_RECORD_VERSION > ::Gem::Version.new('5.1.5')
+    PRE_RAILS_5_1_5 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.1.5')
+    FROM_EAGER_LOADABLE = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.1.5') ||
+      (ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.0.7') && ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.1.0'))
 
     def self.rails_4?
       ::ActiveRecord::VERSION::MAJOR == 4
@@ -16,6 +20,10 @@ module Goldiloader
     # See https://github.com/rails/rails/pull/32375
     def self.destroyed_model_associations_eager_loadable?
       PRE_RAILS_5_2
+    end
+
+    def self.from_eager_loadable?
+      FROM_EAGER_LOADABLE
     end
   end
 end

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 
 module Goldiloader
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -307,7 +307,7 @@ describe Goldiloader do
       blog2.posts.create!(title: 'blog2-post3', author: author1)
     end
 
-    shared_examples "it doesn't auto eager the association" do |association_name|
+    shared_examples "it doesn't auto eager load the association" do |association_name|
       specify do
         blogs.drop(1).each do |blog|
           expect(blog.association(association_name)).to_not be_loaded
@@ -332,7 +332,7 @@ describe Goldiloader do
         expect(blogs.first.limited_posts.to_a.size).to eq 2
       end
 
-      it_behaves_like "it doesn't auto eager the association", :limited_posts
+      it_behaves_like "it doesn't auto eager load the association", :limited_posts
     end
 
     context "associations with a group" do
@@ -344,7 +344,7 @@ describe Goldiloader do
         expect(blogs.first.grouped_posts.to_a.size).to eq 1
       end
 
-      it_behaves_like "it doesn't auto eager the association", :grouped_posts
+      it_behaves_like "it doesn't auto eager load the association", :grouped_posts
     end
 
     context "associations with an offset" do
@@ -356,7 +356,7 @@ describe Goldiloader do
         expect(blogs.first.offset_posts.to_a.size).to eq 1
       end
 
-      it_behaves_like "it doesn't auto eager the association", :offset_posts
+      it_behaves_like "it doesn't auto eager load the association", :offset_posts
     end
 
     context "associations with an overridden from" do
@@ -368,7 +368,11 @@ describe Goldiloader do
         expect(blogs.first.from_posts.to_a.size).to eq 1
       end
 
-      it_behaves_like "it doesn't auto eager the association", :from_posts
+      if ::Goldiloader::Compatibility::ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.0.7')
+        it_behaves_like "it auto eager loads the association", :from_posts
+      else
+        it_behaves_like "it doesn't auto eager load the association", :from_posts
+      end
     end
 
     context "associations with a join" do
@@ -427,7 +431,7 @@ describe Goldiloader do
         expect(blogs.first.instance_dependent_posts.to_a).to match_array(blogs.first.posts)
       end
 
-      it_behaves_like "it doesn't auto eager the association", :instance_dependent_posts
+      it_behaves_like "it doesn't auto eager load the association", :instance_dependent_posts
     end
   end
 


### PR DESCRIPTION
Enable eager loading of associations with a `from` in Rails 5.0.x >= 5.0.7 and Rails >= 5.1.5 because the underlying Rails bug has been fixed.

@will89 - you're prime