### PR TITLE
Enable eager loading of associations with a  group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### 2.1.1
-* Enable eager loading of associations with a `from` in Rails 5.0.x >= 5.0.7 and Rails >= 5.1.5 because
+* Enable eager loading of associations with a `from` or `group` in Rails 5.0.x >= 5.0.7 and Rails >= 5.1.5 because
   the underlying Rails bug has been fixed.
   
 ### 2.1.0

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Associations with any of the following options cannot be eager loaded:
 * `limit`
 * `offset`
 * `finder_sql`
-* `group` (due to a [Rails bug](https://github.com/rails/rails/issues/15854))
+* `group` (only applies to Rails < 5.0.7 and Rails 5.1.x < 5.1.5 due to a [Rails bug](https://github.com/rails/rails/issues/15854))
 * `from` (only applies to Rails < 5.0.7 and Rails 5.1.x < 5.1.5 due to a Rails bug)
 
 Goldiloader detects associations with any of these options and disables automatic eager loading on them.

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -100,7 +100,7 @@ module Goldiloader
       association_info = Goldiloader::AssociationInfo.new(self)
       !association_info.limit? &&
         !association_info.offset? &&
-        !association_info.group? &&
+        (!association_info.group? || ::Goldiloader::Compatibility.group_eager_loadable?) &&
         (!association_info.from? || ::Goldiloader::Compatibility.from_eager_loadable?) &&
         !association_info.instance_dependent? &&
         association_info.auto_include? &&

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -8,6 +8,7 @@ module Goldiloader
     PRE_RAILS_5_1_5 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.1.5')
     FROM_EAGER_LOADABLE = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.1.5') ||
       (ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.0.7') && ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.1.0'))
+    GROUP_EAGER_LOADABLE = FROM_EAGER_LOADABLE
 
     def self.rails_4?
       ::ActiveRecord::VERSION::MAJOR == 4
@@ -24,6 +25,10 @@ module Goldiloader
 
     def self.from_eager_loadable?
       FROM_EAGER_LOADABLE
+    end
+
+    def self.group_eager_loadable?
+      GROUP_EAGER_LOADABLE
     end
   end
 end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -343,8 +343,12 @@ describe Goldiloader do
       it "applies the group correctly" do
         expect(blogs.first.grouped_posts.to_a.size).to eq 1
       end
-
-      it_behaves_like "it doesn't auto eager load the association", :grouped_posts
+      
+      if ::Goldiloader::Compatibility::ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.0.7')
+        it_behaves_like "it auto eager loads the association", :grouped_posts
+      else
+        it_behaves_like "it doesn't auto eager load the association", :grouped_posts
+      end
     end
 
     context "associations with an offset" do


### PR DESCRIPTION
Enable eager loading of associations with a `group` in Rails 5.0.x >= 5.0.7 and Rails >= 5.1.5 because the underlying Rails bug has been fixed.

@will89 - you're prime