### PR TITLE
Do not auto eager load has one associations with order

### DIFF
--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -100,6 +100,7 @@ module Goldiloader
       association_info = Goldiloader::AssociationInfo.new(self)
       !association_info.limit? &&
         !association_info.offset? &&
+        (!association_info.has_one? || !association_info.order?) &&
         (!association_info.group? || ::Goldiloader::Compatibility.group_eager_loadable?) &&
         (!association_info.from? || ::Goldiloader::Compatibility.from_eager_loadable?) &&
         !association_info.instance_dependent? &&

--- a/lib/goldiloader/association_info.rb
+++ b/lib/goldiloader/association_info.rb
@@ -9,6 +9,10 @@ module Goldiloader
 
     delegate :association_scope, :reflection, to: :@association
 
+    def has_one?
+      reflection.has_one?
+    end
+
     def offset?
       association_scope && association_scope.offset_value.present?
     end
@@ -31,6 +35,10 @@ module Goldiloader
 
     def group?
       association_scope && association_scope.group_values.present?
+    end
+
+    def order?
+      association_scope && association_scope.order_values.present?
     end
 
     def instance_dependent?

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -75,6 +75,8 @@ class Blog < ActiveRecord::Base
   has_many :authors, through: :posts
   has_many :addresses, through: :authors
 
+  has_one :post_with_order, -> { order(:id) }, class_name: 'Post'
+
   def posts_overridden
     'boom'
   end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -437,6 +437,18 @@ describe Goldiloader do
 
       it_behaves_like "it doesn't auto eager load the association", :instance_dependent_posts
     end
+
+    context "has_one associations with an order" do
+      before do
+        blogs.first.post_with_order
+      end
+
+      it "applies the scope correctly" do
+        expect(blogs.first.post_with_order).to eq(blogs.first.posts.order(:id).first)
+      end
+
+      it_behaves_like "it doesn't auto eager load the association", :post_with_order
+    end
   end
 
   context "associations with a uniq" do


### PR DESCRIPTION
Since has one associations with an order clause indicates that the
database may have more than one record, we can't auto eager load those.

Closes #61 