### PR TITLE
Drop support for Ruby <= 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ gemfile:
   - gemfiles/rails_5.1.gemfile
   - gemfiles/rails_5.2.gemfile
 rvm:
-  - 2.1.10
-  - 2.2.10
   - 2.3.7
   - 2.4.4
   - 2.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.0.0
+- Drop support for Ruby <= 2.2
+
 ### 2.1.2 
 * Fix [issue 61](https://github.com/salsify/goldiloader/issues/61) - don't eager load has_one associations with an order.
   **Thanks @sobrinho**

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 Wouldn't it be awesome if ActiveRecord didn't make you think about eager loading and it just did the "right" thing by default? With Goldiloader it can!
 
-**This branch only supports Rails 4.2+ with Ruby 2.1+. For older versions of Rails/Ruby use [1-x-stable](https://github.com/salsify/goldiloader/blob/1-x-stable/README.md).**
+**This branch only supports Rails 4.2+ with Ruby 2.3+. For older versions of Rails/Ruby use [2-x-stable](https://github.com/salsify/goldiloader/blob/2-x-stable/README.md)
+or [1-x-stable](https://github.com/salsify/goldiloader/blob/1-x-stable/README.md).**
 
 Consider the following models:
 
@@ -247,7 +248,7 @@ end
 
 ## Status
 
-This gem is tested with Rails 4.2, 5.0, 5.1 and 5.2 using MRI 2.1, 2.2, 2.3, 2.4 and 2.5 and JRuby 9000. 
+This gem is tested with Rails 4.2, 5.0, 5.1 and 5.2 using MRI 2.3, 2.4 and 2.5 and JRuby 9000. 
 
 Let us know if you find any issues or have any other feedback.
 

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files lib Readme.md LICENSE.txt`.split($/)
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'activerecord', '>= 4.2', '< 5.3'
   spec.add_dependency 'activesupport', '>= 4.2', '< 5.3'

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 
 module Goldiloader
-  VERSION = '2.1.2'.freeze
+  VERSION = '3.0.0'.freeze
 end


### PR DESCRIPTION
I hit some issues enabling Rubocop for this project with old version of Ruby. Fortunately their EOL so we can just drop support for them :)

@will89 - you're prime