### PR TITLE
Enable eager loading of associations on destroyed models in Rails 5.2.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.0.1
+- Enable eager loading of associations on destroyed models in all versions of Rails except 5.2.0 since
+  Rails issue [32375](https://github.com/rails/rails/pull/32375) has been fixed.
+
 ### 3.0.0
 * Drop support for Ruby <= 2.2.
 * Use frozen string literals.

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -3,6 +3,7 @@
 module Goldiloader
   module Compatibility
     ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING)
+    RAILS_5_2_0 = ACTIVE_RECORD_VERSION == ::Gem::Version.new('5.2.0')
     PRE_RAILS_5_2 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.2.0')
     POST_RAILS_5_1_4 = ACTIVE_RECORD_VERSION > ::Gem::Version.new('5.1.5')
     PRE_RAILS_5_1_5 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.1.5')
@@ -20,7 +21,7 @@ module Goldiloader
 
     # See https://github.com/rails/rails/pull/32375
     def self.destroyed_model_associations_eager_loadable?
-      PRE_RAILS_5_2
+      RAILS_5_2_0
     end
 
     def self.from_eager_loadable?

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goldiloader
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
Enable eager loading of associations on destroyed models in all versions of Rails except 5.2.0 since
Rails issue [32375](https://github.com/rails/rails/pull/32375) has been fixed.