### PR TITLE
Optimize checks to see if an association is eager loadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.0.1
 - Enable eager loading of associations on destroyed models in all versions of Rails except 5.2.0 since
   Rails issue [32375](https://github.com/rails/rails/pull/32375) has been fixed.
+- Optimize checks to see if an association is eager loadable.
 
 ### 3.0.0
 * Drop support for Ruby <= 2.2.

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -98,14 +98,14 @@ module Goldiloader
 
     def eager_loadable?
       association_info = Goldiloader::AssociationInfo.new(self)
-      !association_info.limit? &&
+      association_info.auto_include? &&
+        !association_info.limit? &&
         !association_info.offset? &&
         (!association_info.has_one? || !association_info.order?) &&
-        (!association_info.group? || ::Goldiloader::Compatibility.group_eager_loadable?) &&
-        (!association_info.from? || ::Goldiloader::Compatibility.from_eager_loadable?) &&
-        !association_info.instance_dependent? &&
-        association_info.auto_include? &&
-        (!owner.destroyed? || ::Goldiloader::Compatibility.destroyed_model_associations_eager_loadable?)
+        (::Goldiloader::Compatibility.group_eager_loadable? || !association_info.group?) &&
+        (::Goldiloader::Compatibility.from_eager_loadable? || !association_info.from?) &&
+        (::Goldiloader::Compatibility.destroyed_model_associations_eager_loadable? || !owner.destroyed?) &&
+        !association_info.instance_dependent?
     end
 
     def load_with_auto_include


### PR DESCRIPTION
This reorders some of the predicates in `AssociationPatch#eager_loadable?` so Ruby can short circuit more of the evaluation for common cases.

@rrunyon - you're prime