### PR TITLE
Remove pessimistic `< 5.3` from activerecord/activesupport dependency

### DIFF
--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'activerecord', '>= 4.2', '< 5.3'
-  spec.add_dependency 'activesupport', '>= 4.2', '< 5.3'
+  spec.add_dependency 'activerecord', '>= 4.2'
+  spec.add_dependency 'activesupport', '>= 4.2'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
There is currently no ActiveRecord or ActiveSupport version 5.3, so we
can't rightly know if this gem will be incompatible. With this change,
we assume that things will work in the as-yet-unknown future.

Tests currently pass (albeit with some deprecation warnings) against Rails edge.