### PR TITLE
Don't test Rails Edge with Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.3.8
   - 2.4.5
   - 2.5.3
+  - 2.6.0
 script:
 - bundle exec rspec
 - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,15 @@ gemfile:
   - gemfiles/rails_5.2.gemfile
   - gemfiles/rails_edge.gemfile
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 script:
 - bundle exec rspec
 - bundle exec rubocop
 matrix:
   exclude:
-  - rvm: 2.3.7
+  - rvm: 2.3.8
+    gemfile: gemfiles/rails_edge.gemfile
+  - rvm: 2.4.5
     gemfile: gemfiles/rails_edge.gemfile

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ end
 
 ## Status
 
-This gem is tested with Rails 4.2, 5.0, 5.1 and 5.2 using MRI 2.3, 2.4 and 2.5 and JRuby 9000. 
+This gem is tested with Rails 4.2, 5.0, 5.1, 5.2 and Edge using MRI 2.3, 2.4, 2.5 and 2.6. 
 
 Let us know if you find any issues or have any other feedback.
 


### PR DESCRIPTION
Rails 6.0 requires Ruby 2.5+. I also bumped the MRI point releases we're testing with and add Ruby 2.6 tests while I was in here.