### PR TITLE
Fix build failure from new sqlite version

### DIFF
--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -4,6 +4,5 @@ source "https://rubygems.org"
 
 gem "activerecord", "4.2.10"
 gem "activesupport", "4.2.10"
-gem "activerecord-jdbcsqlite3-adapter", "~> 1.3.24", platforms: :jruby
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'salsify_rubocop', '0.52.1.1'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.13'
 end


### PR DESCRIPTION
This builds are failing now that sqlite3 1.4.0 has been released because Rails has an [explicit dependency](https://github.com/rails/rails/blob/v5.2.2/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L12) on this version of sqlite3 that isn't declared in its gemspec. See https://github.com/rails/rails/issues/35153 for more info. For now the easiest thing to do is pin the tests to sqlite3 1.3.x.

@will89 - you're prime