### PR TITLE
Upgrade to versions of Rails with more flexible sqlite dependencies

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
 appraise 'rails-4.2' do
-  gem 'activerecord', '4.2.10'
-  gem 'activesupport', '4.2.10'
+  gem 'sqlite3', '~> 1.3.6'
+  gem 'activerecord', '4.2.11.1'
+  gem 'activesupport', '4.2.11.1'
 end
 
 appraise 'rails-5.0' do
-  gem 'activerecord', '5.0.7'
-  gem 'activesupport', '5.0.7'
+  gem 'sqlite3', '~> 1.3.6'
+  gem 'activerecord', '5.0.7.2'
+  gem 'activesupport', '5.0.7.2'
 end
 
 appraise 'rails-5.1' do
-  gem 'activerecord', '5.1.6'
-  gem 'activesupport', '5.1.6'
+  gem 'activerecord', '5.1.7'
+  gem 'activesupport', '5.1.7'
 end
 
 appraise 'rails-5.2' do
-  gem 'activerecord', '5.2.2 '
-  gem 'activesupport', '5.2.2 '
+  gem 'activerecord', '5.2.3 '
+  gem 'activesupport', '5.2.3 '
 end
 
 appraise 'rails-edge' do

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "4.2.10"
-gem "activesupport", "4.2.10"
+gem "sqlite3", "~> 1.3.6"
+gem "activerecord", "4.2.11.1"
+gem "activesupport", "4.2.11.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -2,7 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.0.7"
-gem "activesupport", "5.0.7"
+gem "sqlite3", "~> 1.3.6"
+gem "activerecord", "5.0.7.2"
+gem "activesupport", "5.0.7.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.1.6"
-gem "activesupport", "5.1.6"
+gem "activerecord", "5.1.7"
+gem "activesupport", "5.1.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.2.2 "
-gem "activesupport", "5.2.2 "
+gem "activerecord", "5.2.3 "
+gem "activesupport", "5.2.3 "
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'salsify_rubocop', '0.52.1.1'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.13'
+  spec.add_development_dependency 'sqlite3', '~> 1.3'
 end


### PR DESCRIPTION
Now that https://github.com/rails/rails/issues/35153 has been fixed in Rails 5.1+ we can use a less restrict version specifier for the sqlite development dependency. This fixes the sqlite errors we were hitting in Rails Edge builds but now Rails Edge builds are failing for a different reason. I'll fix that in another PR.

@will89 - you're prime