### PR TITLE
Enable Travis gem caching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.3
+  Exclude:
+    - 'vendor/**/*'
+    - 'gemfiles/vendor/**/*'
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 sudo: false
 gemfile:
   - gemfiles/rails_4.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,5 @@ matrix:
     gemfile: gemfiles/rails_edge.gemfile
   - rvm: 2.4.5
     gemfile: gemfiles/rails_edge.gemfile
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,3 @@ matrix:
     gemfile: gemfiles/rails_edge.gemfile
   - rvm: 2.4.5
     gemfile: gemfiles/rails_edge.gemfile
-notifications:
-  webhooks: https://coveralls.io/webhook

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,8 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
 )
 
 SimpleCov.start do
+  add_filter 'benchmark'
+  add_filter 'gemfiles'
   add_filter 'spec'
 end
 


### PR DESCRIPTION
Enable Travis' gem [caching](https://docs.travis-ci.com/user/caching/) to cut CI time 30%. Note I had to update the rubocop config to exclude the gems that are not being installed in the vendor directory.