### PR TITLE
Upgrade Test Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,13 @@ gemfile:
   - gemfiles/rails_6.0.gemfile
   - gemfiles/rails_edge.gemfile
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 script:
 - bundle exec rspec
 - bundle exec rubocop
 matrix:
   exclude:
-  - rvm: 2.3.8
-    gemfile: gemfiles/rails_6.0.gemfile
-  - rvm: 2.4.5
-    gemfile: gemfiles/rails_6.0.gemfile
-  - rvm: 2.3.8
-    gemfile: gemfiles/rails_edge.gemfile
-  - rvm: 2.4.5
-    gemfile: gemfiles/rails_edge.gemfile
+  - rvm: 2.7.1
+    gemfile: gemfiles/rails_4.2.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -2,8 +2,8 @@
 
 appraise 'rails-4.2' do
   gem 'sqlite3', '~> 1.3.6'
-  gem 'activerecord', '4.2.11.1'
-  gem 'activesupport', '4.2.11.1'
+  gem 'activerecord', '4.2.11.3'
+  gem 'activesupport', '4.2.11.3'
 end
 
 appraise 'rails-5.0' do
@@ -18,13 +18,13 @@ appraise 'rails-5.1' do
 end
 
 appraise 'rails-5.2' do
-  gem 'activerecord', '5.2.3'
-  gem 'activesupport', '5.2.3'
+  gem 'activerecord', '5.2.4.4'
+  gem 'activesupport', '5.2.4.4'
 end
 
 appraise 'rails-6.0' do
-  gem 'activerecord', '6.0.0'
-  gem 'activesupport', '6.0.0'
+  gem 'activerecord', '6.0.3.3 '
+  gem 'activesupport', '6.0.3.3 '
 end
 
 appraise 'rails-edge' do

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "sqlite3", "~> 1.3.6"
-gem "activerecord", "4.2.11.1"
-gem "activesupport", "4.2.11.1"
+gem "activerecord", "4.2.11.3"
+gem "activesupport", "4.2.11.3"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "5.2.3"
-gem "activesupport", "5.2.3"
+gem "activerecord", "5.2.4.4"
+gem "activesupport", "5.2.4.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "6.0.0"
-gem "activesupport", "6.0.0"
+gem "activerecord", "6.0.3.3 "
+gem "activesupport", "6.0.3.3 "
 
 gemspec path: "../"


### PR DESCRIPTION
This upgrades the test matrix to the latest versions of Ruby and Rails. It also drops testing of EOL Ruby 2.3 and 2.4 and adds testing with Ruby 2.7. 