### PR TITLE
Rails 6.1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ workflows:
               - "gemfiles/rails_5.1.gemfile"
               - "gemfiles/rails_5.2.gemfile"
               - "gemfiles/rails_6.0.gemfile"
+              - "gemfiles/rails_6.1.gemfile"
               - "gemfiles/rails_edge.gemfile"
               ruby_version:
               - "2.5.8"

--- a/Appraisals
+++ b/Appraisals
@@ -23,8 +23,13 @@ appraise 'rails-5.2' do
 end
 
 appraise 'rails-6.0' do
-  gem 'activerecord', '6.0.3.3 '
-  gem 'activesupport', '6.0.3.3 '
+  gem 'activerecord', '6.0.3.4'
+  gem 'activesupport', '6.0.3.4'
+end
+
+appraise 'rails-6.1' do
+  gem 'activerecord', '6.1.0'
+  gem 'activesupport', '6.1.0'
 end
 
 appraise 'rails-edge' do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.2.0
+- Rails 6.1 support.
+
 ### 3.1.1
 - Fix to support Rails 6.0 beta 3.
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ end
 
 ## Status
 
-This gem is tested with Rails 4.2, 5.0, 5.1, 5.2 and Edge using MRI 2.3, 2.4, 2.5 and 2.6. 
+This gem is tested with Rails 4.2, 5.0, 5.1, 5.2, 6.0, 6.1 and Edge using MRI 2.5, 2.6 and 2.7. 
 
 Let us know if you find any issues or have any other feedback.
 

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "6.0.3.4"
-gem "activesupport", "6.0.3.4"
+gem "activerecord", "6.1.0"
+gem "activesupport", "6.1.0"
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'activerecord', '>= 4.2', '< 6.2'
-  spec.add_dependency 'activesupport', '>= 4.2', '< 6.2'
+  spec.add_dependency 'activerecord', '>= 4.2', '< 6.3'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 6.3'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goldiloader
-  VERSION = '3.1.1'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
This PR adds official support for Rails 6.1 and bumps our testing of Rails Edge to be compatible with Rails 6.2.

Fixes #97 #98 