### PR TITLE
Fix Rails Edge for changes in ActiveRecord::Associations::Preloader API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.2.1 (Unreleased)
+- Fix Rails Edge for changes in `ActiveRecord::Associations::Preloader` API.
+
 ### 3.2.0
 - Rails 6.1 support.
 

--- a/lib/goldiloader/association_loader.rb
+++ b/lib/goldiloader/association_loader.rb
@@ -15,7 +15,11 @@ module Goldiloader
     private
 
     def eager_load(models, association_name)
-      ::ActiveRecord::Associations::Preloader.new.preload(models, [association_name])
+      if Goldiloader::Compatibility.pre_rails_6_2?
+        ::ActiveRecord::Associations::Preloader.new.preload(models, [association_name])
+      else
+        ::ActiveRecord::Associations::Preloader.new(records: models, associations: [association_name]).call
+      end
     end
 
     def load?(model, association_name)

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -2,7 +2,8 @@
 
 module Goldiloader
   module Compatibility
-    ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING)
+    ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING).release
+    PRE_RAILS_6_2 = ACTIVE_RECORD_VERSION < ::Gem::Version.new('6.2.0')
     RAILS_5_2_0 = ACTIVE_RECORD_VERSION == ::Gem::Version.new('5.2.0')
     FROM_EAGER_LOADABLE = ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.1.5') ||
       (ACTIVE_RECORD_VERSION >= ::Gem::Version.new('5.0.7') && ACTIVE_RECORD_VERSION < ::Gem::Version.new('5.1.0'))
@@ -10,6 +11,10 @@ module Goldiloader
 
     def self.rails_4?
       ::ActiveRecord::VERSION::MAJOR == 4
+    end
+
+    def self.pre_rails_6_2?
+      PRE_RAILS_6_2
     end
 
     # See https://github.com/rails/rails/pull/32375

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goldiloader
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end


### PR DESCRIPTION
The Rails internal `ActiveRecord::Associations::Preloader` API changed in https://github.com/rails/rails/pull/40776 so we need to make a corresponding change in goldiloader.