### PR TITLE
Fix Rails edge builds

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -33,6 +33,6 @@ appraise 'rails-6.1' do
 end
 
 appraise 'rails-edge' do
-  gem 'activerecord', github: 'rails/rails'
-  gem 'activesupport', github: 'rails/rails'
+  gem 'activerecord', github: 'rails/rails', branch: 'main'
+  gem 'activesupport', github: 'rails/rails', branch: 'main'
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", git: "https://github.com/rails/rails.git"
-gem "activesupport", git: "https://github.com/rails/rails.git"
+gem "activerecord", branch: "main", git: "https://github.com/rails/rails.git"
+gem "activesupport", branch: "main", git: "https://github.com/rails/rails.git"
 
 gemspec path: "../"


### PR DESCRIPTION
Rails changed their default branch from `master` to `main` so we need to make a corresponding change to our CI builds.

@will89 - you're prime