### PR TITLE
Fix Rails Edge builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,14 @@ workflows:
               ruby_version:
               - "2.5.8"
               - "2.6.6"
-              - "2.7.1"
+              - "2.7.2"
             exclude:
               - gemfile: "gemfiles/rails_4.2.gemfile"
-                ruby_version: "2.7.1"
+                ruby_version: "2.7.2"
+              - gemfile: "gemfiles/rails_edge.gemfile"
+                ruby_version: "2.5.8"
+              - gemfile: "gemfiles/rails_edge.gemfile"
+                ruby_version: "2.6.6"
   weekly_rails_edge:
     triggers:
       - schedule:
@@ -106,4 +110,4 @@ workflows:
               gemfile:
                 - "gemfiles/rails_edge.gemfile"
               ruby_version:
-                - "2.7.1"
+                - "2.7.2"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3'
 
-  spec.add_dependency 'activerecord', '>= 4.2', '< 6.3'
-  spec.add_dependency 'activesupport', '>= 4.2', '< 6.3'
+  spec.add_dependency 'activerecord', '>= 4.2', '< 7.1'
+  spec.add_dependency 'activesupport', '>= 4.2', '< 7.1'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
Looks like the next major Rails release will be 7.0 rather than 6.2 and it will only support Ruby 2.7+ so update our build configuration to support testing that.