### PR TITLE
Fix Rails Edge tests

### DIFF
--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -56,10 +56,6 @@ describe Goldiloader do
   end
 
   before do
-    [Address, Blog, Post, Tag, User, Group].each do |klass|
-      allow(klass).to receive(:find_by_sql).and_call_original
-    end
-
     ActiveRecord::Base.logger.info('Test setup complete')
   end
 
@@ -71,17 +67,17 @@ describe Goldiloader do
       expect(blog.association(:posts)).not_to be_loaded
     end
 
-    # Force the first blogs first post to load
-    blogs.first.posts.to_a
+    expect do
+      # Force the first blogs first post to load
+      blogs.first.posts.to_a
 
-    blogs.each do |blog|
-      expect(blog.association(:posts)).to be_loaded
-    end
+      blogs.each do |blog|
+        expect(blog.association(:posts)).to be_loaded
+      end
 
-    expect(blogs.first.posts.map(&:title)).to match_array(['blog1-post1', 'blog1-post2'])
-    expect(blogs.second.posts.map(&:title)).to match_array(['blog2-post1', 'blog2-post2'])
-
-    expect(Post).to have_received(:find_by_sql).once
+      expect(blogs.first.posts.map(&:title)).to match_array(['blog1-post1', 'blog1-post2'])
+      expect(blogs.second.posts.map(&:title)).to match_array(['blog2-post1', 'blog2-post2'])
+    end.to execute_queries(Post => 1)
   end
 
   it "auto eager loads belongs_to associations" do
@@ -92,15 +88,16 @@ describe Goldiloader do
       expect(blog.association(:blog)).not_to be_loaded
     end
 
-    # Force the first post's blog to load
-    posts.first.blog
+    expect do
+      # Force the first post's blog to load
+      posts.first.blog
 
-    posts.each do |blog|
-      expect(blog.association(:blog)).to be_loaded
-    end
+      posts.each do |blog|
+        expect(blog.association(:blog)).to be_loaded
+      end
 
-    expect(posts.map(&:blog).map(&:name)).to eq(['blog1', 'blog1', 'blog2', 'blog2'])
-    expect(Blog).to have_received(:find_by_sql).once
+      expect(posts.map(&:blog).map(&:name)).to eq(['blog1', 'blog1', 'blog2', 'blog2'])
+    end.to execute_queries(Blog => 1)
   end
 
   it "auto eager loads has_one associations" do
@@ -111,56 +108,63 @@ describe Goldiloader do
       expect(user.association(:address)).not_to be_loaded
     end
 
-    # Force the first user's address to load
-    users.first.address
+    expect do
+      # Force the first user's address to load
+      users.first.address
 
-    users.each do |blog|
-      expect(blog.association(:address)).to be_loaded
-    end
+      users.each do |blog|
+        expect(blog.association(:address)).to be_loaded
+      end
 
-    expect(users.map(&:address).map(&:city)).to match_array(['author1-city', 'author2-city', 'author3-city'])
-    expect(Address).to have_received(:find_by_sql).once
+      expect(users.map(&:address).map(&:city)).to match_array(['author1-city', 'author2-city', 'author3-city'])
+    end.to execute_queries(Address => 1)
   end
 
   it "auto eager loads nested associations" do
     blogs = Blog.order(:name).to_a
-    blogs.first.posts.to_a.first.author
 
-    blogs.flat_map(&:posts).each do |blog|
-      expect(blog.association(:author)).to be_loaded
-    end
+    expect do
+      blogs.first.posts.to_a.first.author
 
-    expect(blogs.first.posts.first.author).to eq author1
-    expect(blogs.first.posts.second.author).to eq author2
-    expect(blogs.second.posts.first.author).to eq author3
-    expect(blogs.second.posts.second.author).to eq author1
-    expect(Post).to have_received(:find_by_sql).once
+      blogs.flat_map(&:posts).each do |blog|
+        expect(blog.association(:author)).to be_loaded
+      end
+
+      expect(blogs.first.posts.first.author).to eq author1
+      expect(blogs.first.posts.second.author).to eq author2
+      expect(blogs.second.posts.first.author).to eq author3
+      expect(blogs.second.posts.second.author).to eq author1
+    end.to execute_queries(Post => 1, User => 1)
   end
 
   it "auto eager loads has_many through associations" do
     blogs = Blog.order(:name).to_a
-    blogs.first.authors.to_a
 
-    blogs.each do |blog|
-      expect(blog.association(:authors)).to be_loaded
-    end
+    expect do
+      blogs.first.authors.to_a
 
-    expect(blogs.first.authors).to match_array([author1, author2])
-    expect(blogs.second.authors).to match_array([author3, author1])
-    expect(User).to have_received(:find_by_sql).once
+      blogs.each do |blog|
+        expect(blog.association(:authors)).to be_loaded
+      end
+
+      expect(blogs.first.authors).to match_array([author1, author2])
+      expect(blogs.second.authors).to match_array([author3, author1])
+    end.to execute_queries(Post => 1, User => 1)
   end
 
   it "auto eager loads nested has_many through associations" do
     blogs = Blog.order(:name).to_a
-    blogs.first.addresses.to_a
 
-    blogs.each do |blog|
-      expect(blog.association(:addresses)).to be_loaded
-    end
+    expect do
+      blogs.first.addresses.to_a
 
-    expect(blogs.first.addresses).to match_array([author1, author2].map(&:address))
-    expect(blogs.second.addresses).to match_array([author3, author1].map(&:address))
-    expect(Address).to have_received(:find_by_sql).once
+      blogs.each do |blog|
+        expect(blog.association(:addresses)).to be_loaded
+      end
+
+      expect(blogs.first.addresses).to match_array([author1, author2].map(&:address))
+      expect(blogs.second.addresses).to match_array([author3, author1].map(&:address))
+    end.to execute_queries(Post => 1, User => 1, Address => 1)
   end
 
   it "auto eager loads associations when the model is loaded via find" do
@@ -260,23 +264,22 @@ describe Goldiloader do
   end
 
   context "with manual eager loading" do
-    let(:blogs) { Blog.order(:name).send(load_method, :posts).to_a }
-
-    before do
-      blogs.first.posts.to_a.first.author
-    end
-
     shared_examples "it auto-eager loads associations of manually eager loaded associations" do
       specify do
-        blogs.flat_map(&:posts).drop(1).each do |blog|
-          expect(blog.association(:author)).to be_loaded
-        end
+        blogs = Blog.order(:name).send(load_method, :posts).to_a
 
-        expect(blogs.first.posts.first.author).to eq author1
-        expect(blogs.first.posts.second.author).to eq author2
-        expect(blogs.second.posts.first.author).to eq author3
-        expect(blogs.second.posts.second.author).to eq author1
-        expect(Post).to have_received(:find_by_sql).at_most(:once)
+        expect do
+          blogs.first.posts.to_a.first.author
+
+          blogs.flat_map(&:posts).drop(1).each do |blog|
+            expect(blog.association(:author)).to be_loaded
+          end
+
+          expect(blogs.first.posts.first.author).to eq author1
+          expect(blogs.first.posts.second.author).to eq author2
+          expect(blogs.second.posts.first.author).to eq author3
+          expect(blogs.second.posts.second.author).to eq author1
+        end.to execute_queries(User => 1)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,4 +49,32 @@ RSpec.configure do |config|
   end
 end
 
+# Takes a hash from model class to the number of expected queries executed for that model e.g.
+# expect {  }.to execute_queries(Post => 2, User => 1)
+RSpec::Matchers.define(:execute_queries) do |expected_counts|
+  match(notify_expectation_failures: true) do |actual|
+    @actual_queries = []
+    listener = lambda do |_name, _start, _finish, _message_id, values|
+      @actual_queries << values[:sql]
+    end
+
+    ActiveSupport::Notifications.subscribed(listener, 'sql.active_record', &actual)
+
+    expected_counts_by_table = expected_counts.transform_keys(&:table_name)
+
+    table_extractor = /SELECT .* FROM "(.+)" WHERE/
+    actual_counts_by_table = @actual_queries.group_by do |query|
+      table_extractor.match(query)[1]
+    end.transform_values(&:size)
+
+    actual_counts_by_table == expected_counts_by_table
+  end
+
+  failure_message do |_actual|
+    "expected #{expected_counts.transform_keys(&:name)} queries but ran:\n#{@actual_queries.join("\n")}"
+  end
+
+  supports_block_expectations
+end
+
 puts "Testing with ActiveRecord #{ActiveRecord::VERSION::STRING}"


### PR DESCRIPTION
Rails Edge changed the implementation of `ActiveRecord::Relation` to call `ActiveRecord::Base. _query_by_sql` rather than `ActiveRecord::Base. find_by_sql` in commit [2a90104989b9f1653337d08871610d394b2d626d](https://github.com/rails/rails/commit/2a90104989b9f1653337d08871610d394b2d626d#diff-18a561656864ea240daf46bdb1f50faace49f9ef74b90bcf667d9bbb17fce084R923) which broke a bunch of tests that rely on spying on calls to `ActiveRecord::Base. find_by_sql`. This PR fixes the failing tests by using an ActiveSupport subscriber on [sql.active_record](https://guides.rubyonrails.org/active_support_instrumentation.html#sql-active-record) events to spy on query execution. This should make the tests more resilient to future changes in Rails and avoids introducing a dependency on a 3rd party gem.