### PR TITLE
Handle polymorphic associations with scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 4.0.1
+- Fix issue [105](https://github.com/salsify/goldiloader/issues/105) - Handle polymorphic associations with scopes.
+
 ### 4.0.0
 - Fix Rails Edge for changes in `ActiveRecord::Associations::Preloader` API.
 - Add support for Ruby 3.0.  

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goldiloader
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -45,6 +45,8 @@ class Tag < ActiveRecord::Base
   has_many :children, class_name: 'Tag', foreign_key: :parent_id
 
   belongs_to :owner, polymorphic: true
+  belongs_to :scoped_owner, -> { where("name like 'author%'") }, polymorphic: true,
+             foreign_key: :owner_id, foreign_type: :owner_type
   has_many :post_tags
   has_many :posts, through: :post_tags
 end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -202,6 +202,21 @@ describe Goldiloader do
     expect(users.second.posts).to eq Post.where(author_id: author2.id)
   end
 
+  it "auto eager loads polymorphic associations with scopes" do
+    hidden_user = User.create!(name: 'oddball')
+    Tag.where(owner: group1).update_all(owner_type: 'User', owner_id: hidden_user.id)
+    tags = Tag.where('parent_id IS NOT NULL').order(:name).to_a
+    tags.first.scoped_owner
+
+    tags.each do |tag|
+      expect(tag.association(:scoped_owner)).to be_loaded
+    end
+
+    expect(tags.first.scoped_owner).to eq author1
+    expect(tags.second.scoped_owner).to be_nil
+    expect(tags.third.scoped_owner).to eq author2
+  end
+
   it "sets inverse associations properly" do
     blogs = Blog.order(:name).to_a
 


### PR DESCRIPTION
This PR fixes an issue that caused loading polymorphic associations with scopes to raise an error as described in #105. Our checking to see if an association could be eager loaded relied on the target class of the association to evaluate the association's scope block and then look for problematic constructs like offsets or limits. This doesn't work for polymorphic associations because the target association class won't be known outside the context of a given association instance.

The fix is to defer the computation as to whether or not an association is eager loadable until we know the association instance's target class but retain the performance optimizations from #78 by caching this information.

Fixes #105.

/cc @luizkowalski 