### PR TITLE
Do not persist globally enabled in threads

### DIFF
--- a/lib/goldiloader.rb
+++ b/lib/goldiloader.rb
@@ -24,7 +24,7 @@ module Goldiloader
     end
 
     def enabled
-      old_enabled = enabled?
+      old_enabled = Thread.current[:goldiloader_enabled]
       self.enabled = true
       yield
     ensure
@@ -32,7 +32,7 @@ module Goldiloader
     end
 
     def disabled
-      old_enabled = enabled?
+      old_enabled = Thread.current[:goldiloader_enabled]
       self.enabled = false
       yield
     ensure

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -1002,6 +1002,24 @@ describe Goldiloader do
         Thread.new { expect(Goldiloader.enabled?).to be false }.join
       end
     end
+
+    it "doesn't persist the global value on the thread when using a block" do
+      Thread.current[:goldiloader_enabled] = nil
+
+      Goldiloader.globally_enabled = true
+      Goldiloader.disabled do
+        expect(Goldiloader.enabled?).to be false
+      end
+      expect(Goldiloader.enabled?).to be true
+      expect(Thread.current[:goldiloader_enabled]).to eq nil
+
+      Goldiloader.globally_enabled = false
+      Goldiloader.enabled do
+        expect(Goldiloader.enabled?).to be true
+      end
+      expect(Goldiloader.enabled?).to be false
+      expect(Thread.current[:goldiloader_enabled]).to eq nil
+    end
   end
 
   describe "CollectionProxy#exists?" do


### PR DESCRIPTION
This fixes a subtle bug that can cause unpredictable behavior if `globally_enabled` is changed (i.e. during app initialization).

With the current code, whenever `enabled` or `disabled` is called with a block, the previous value is restored to the thread local variable. However, if the previous value was not set, then the value that is stored is the value of `globally_enabled`.

Consider this contrived example:

```ruby
Goldiloader.globally_enabled = true

ThreadPool.run do
  Goldiloader.enabled { do_thing } # Thread[: goldiloader_enabled] now set to true in this thread
end

Goldiloader.globally_enabled = false

ThreadPool.run do
  Goldiloader.enabled { do_thing } # Thread[: goldiloader_enabled] now set to false in this thread
end
```

Now, assuming we had two different threads running in the thread pool, we have two different states for `Goldiloader.enabled`. I would expect that changing the global setting would change the default state for all threads.