### PR TITLE
Rails 7.0/Ruby 3.1 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.6.6
+      - image: salsify/ruby_ci:2.6.8
     working_directory: ~/goldiloader
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.6.6-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.6.6-
+            - v1-gems-ruby-2.6.8-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.6.8-
       - run:
           name: Install Gems
           command: |
@@ -18,7 +18,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.6.6-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-2.6.8-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -80,18 +80,22 @@ workflows:
               - "gemfiles/rails_5.2.gemfile"
               - "gemfiles/rails_6.0.gemfile"
               - "gemfiles/rails_6.1.gemfile"
+              - "gemfiles/rails_7.0.gemfile"
               - "gemfiles/rails_edge.gemfile"
               ruby_version:
-              - "2.6.6"
-              - "2.7.2"
-              - "3.0.0"
+              - "2.6.8"
+              - "2.7.4"
+              - "3.0.3"
+              - "3.1.0"
             exclude:
               - gemfile: "gemfiles/rails_5.2.gemfile"
-                ruby_version: "3.0.0"
-              - gemfile: "gemfiles/rails_6.0.gemfile"
-                ruby_version: "3.0.0"
+                ruby_version: "3.0.3"
+              - gemfile: "gemfiles/rails_5.2.gemfile"
+                ruby_version: "3.1.0"
+              - gemfile: "gemfiles/rails_7.0.gemfile"
+                ruby_version: "2.6.8"
               - gemfile: "gemfiles/rails_edge.gemfile"
-                ruby_version: "2.6.6"
+                ruby_version: "2.6.8"
   weekly_rails_edge:
     triggers:
       - schedule:
@@ -107,4 +111,4 @@ workflows:
               gemfile:
                 - "gemfiles/rails_edge.gemfile"
               ruby_version:
-                - "2.7.2"
+                - "3.1.0"

--- a/Appraisals
+++ b/Appraisals
@@ -7,15 +7,21 @@ appraise 'rails-5.2' do
 end
 
 appraise 'rails-6.0' do
-  gem 'activerecord', '6.0.4.1'
-  gem 'activesupport', '6.0.4.1'
-  gem 'activestorage', '6.0.4.1'
+  gem 'activerecord', '6.0.4.4'
+  gem 'activesupport', '6.0.4.4'
+  gem 'activestorage', '6.0.4.4'
 end
 
 appraise 'rails-6.1' do
-  gem 'activerecord', '6.1.4.1'
-  gem 'activesupport', '6.1.4.1'
-  gem 'activestorage', '6.1.4.1'
+  gem 'activerecord', '6.1.4.4'
+  gem 'activesupport', '6.1.4.4'
+  gem 'activestorage', '6.1.4.4'
+end
+
+appraise 'rails-7.0' do
+  gem 'activerecord', '7.0.1'
+  gem 'activesupport', '7.0.1'
+  gem 'activestorage', '7.0.1'
 end
 
 appraise 'rails-edge' do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.0
+- Add support for Rails 7.0 and Ruby 3.1.
+
 ## 4.1.2
 - Fix issue [88](https://github.com/salsify/goldiloader/issues/88) which resulted in a stack overflow when
   navigating from an `ActiveStorage::Attachment` to its associated `ActiveStorage::Blob`.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ end
 
 ## Status
 
-This gem is tested with Rails 5.2, 6.0, 6.1 and Edge using MRI 2.6, 2.7 and 3.0. 
+This gem is tested with Rails 5.2, 6.0, 6.1, 7.0 and Edge using MRI 2.6, 2.7, 3.0 and 3.1. 
 
 Let us know if you find any issues or have any other feedback.
 

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "6.1.4.1"
-gem "activesupport", "6.1.4.1"
-gem "activestorage", "6.1.4.1"
+gem "activerecord", "6.1.4.4"
+gem "activesupport", "6.1.4.4"
+gem "activestorage", "6.1.4.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "6.0.4.4"
-gem "activesupport", "6.0.4.4"
-gem "activestorage", "6.0.4.4"
+gem "activerecord", "7.0.1"
+gem "activesupport", "7.0.1"
+gem "activestorage", "7.0.1"
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -31,10 +31,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency 'activerecord', '>= 5.2', '< 7.1'
-  spec.add_dependency 'activesupport', '>= 5.2', '< 7.1'
+  spec.add_dependency 'activerecord', '>= 5.2', '< 7.2'
+  spec.add_dependency 'activesupport', '>= 5.2', '< 7.2'
 
-  spec.add_development_dependency 'activestorage', '>= 5.2', '< 7.1'
+  spec.add_development_dependency 'activestorage', '>= 5.2', '< 7.2'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'coveralls_reborn', '>= 0.18.0'

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goldiloader
-  VERSION = '4.1.2'
+  VERSION = '4.2.0'
 end


### PR DESCRIPTION
This PR adds support for Rails 7.0 and Ruby 3.1. It also bumps the test matrix to use the latest point releases of Ruby/Rails.