### PR TITLE
Add Ruby 3.2 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,18 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: salsify/ruby_ci:2.6.8
+      - image: salsify/ruby_ci:2.6.10
     working_directory: ~/goldiloader
     steps:
       - checkout
       - run:
-          # This is only needed for Ruby 2.6.8 which has an old version of SQLite
+          # This is only needed for Ruby 2.6.10 which has an old version of SQLite
           name: Install SQLite
           command: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - restore_cache:
           keys:
-            - v1-gems-ruby-2.6.8-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
-            - v1-gems-ruby-2.6.8-
+            - v1-gems-ruby-2.6.10-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-2.6.10-
       - run:
           name: Install Gems
           command: |
@@ -22,7 +22,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-2.6.8-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-2.6.10-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -45,10 +45,10 @@ jobs:
       - checkout
       - when:
           condition:
-            equal: [ "2.6.8", << parameters.ruby_version >> ]
+            equal: [ "2.6.10", << parameters.ruby_version >> ]
           steps:
           - run:
-              # This is only needed for Ruby 2.6.8 which has an old version of SQLite
+              # This is only needed for Ruby 2.6.10 which has an old version of SQLite
               name: Install SQLite
               command: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - unless:
@@ -95,19 +95,22 @@ workflows:
               - "gemfiles/rails_7.0.gemfile"
               - "gemfiles/rails_edge.gemfile"
               ruby_version:
-              - "2.6.8"
-              - "2.7.6"
-              - "3.0.4"
-              - "3.1.2"
+              - "2.6.10"
+              - "2.7.7"
+              - "3.0.5"
+              - "3.1.3"
+              - "3.2.0"
             exclude:
               - gemfile: "gemfiles/rails_5.2.gemfile"
-                ruby_version: "3.0.4"
+                ruby_version: "3.0.5"
               - gemfile: "gemfiles/rails_5.2.gemfile"
-                ruby_version: "3.1.2"
+                ruby_version: "3.1.3"
+              - gemfile: "gemfiles/rails_5.2.gemfile"
+                ruby_version: "3.2.0"
               - gemfile: "gemfiles/rails_7.0.gemfile"
-                ruby_version: "2.6.8"
+                ruby_version: "2.6.10"
               - gemfile: "gemfiles/rails_edge.gemfile"
-                ruby_version: "2.6.8"
+                ruby_version: "2.6.10"
   weekly_rails_edge:
     triggers:
       - schedule:
@@ -123,4 +126,4 @@ workflows:
               gemfile:
                 - "gemfiles/rails_edge.gemfile"
               ruby_version:
-                - "3.1.2"
+                - "3.2.0"


### PR DESCRIPTION
This PR adds Ruby 3.2 to the test matrix and bumps the patch versions for the other Ruby versions.