### PR TITLE
Implement custom preloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ class Blog < ActiveRecord::Base
   
   def posts_count
     goldiload(:posts_count) do |ids|
-      # this block will only be executed once
+      # By default, `ids` will be a list of `Blog#id`s
       Post
         .where(blog_id: ids)
         .group(:blog_id)
@@ -305,7 +305,7 @@ end
 
 The first time you call the `posts_count` method, it will call the block with all model ids from the current context and reuse the result from the block for all other models in the context.
 
-A more complex example:
+A more complex example might use a custom primary key instead of `id`, use a non ActiveRecord API and have more complex return values than just scalar values:
 
 ```ruby
 class Blog < ActiveRecord::Base

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ The first time you call the `posts_count` method, it will call the block with al
 
 A more complex example might use a custom primary key instead of `id`, use a non ActiveRecord API and have more complex return values than just scalar values:
 
+
 ```ruby
 class Post < ActiveRecord::Base
   def main_translator_reference
@@ -328,6 +329,11 @@ end
 ```
 
 **Note:** The `goldiload` method will use the `source_location` of the given block as a cache name to distinguish between multiple defined preloads. If this causes an issue for you, you can also pass a cache name explicitly as the first argument to the `goldiload` method.
+
+
+### Gotchas
+
+Even though the methods in the examples above (`posts_count`, `main_translator`) are actually instance methods, the block passed to `goldiload` should not contain any references to these instances, as this could break the internal lookup/caching mechanism. We prevent this for the `self` keyword, so you'll get a `NoMethodError`. If you get this, you might want to think about the implementation rather than just trying to work around the exception.
 
 
 ## Upgrading

--- a/lib/goldiloader.rb
+++ b/lib/goldiloader.rb
@@ -3,6 +3,7 @@
 require 'active_support/all'
 require 'active_record'
 require 'goldiloader/compatibility'
+require 'goldiloader/custom_preloads'
 require 'goldiloader/auto_include_context'
 require 'goldiloader/scope_info'
 require 'goldiloader/association_options'

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -26,7 +26,7 @@ module Goldiloader
       super
     end
 
-    def goldiload(cache_name=nil, key: self.class.primary_key, &block)
+    def goldiload(cache_name = nil, key: self.class.primary_key, &block)
       cache_name ||= block.source_location.join(':')
       auto_include_context.preloaded(self, cache_name: cache_name, key: key, &block)
     end

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -26,8 +26,9 @@ module Goldiloader
       super
     end
 
-    def goldiload(name, primary_key: :id, &block)
-      auto_include_context.preloaded(self, name, primary_key: primary_key, &block)
+    def goldiload(cache_name=nil, key: self.class.primary_key, &block)
+      cache_name ||= block.source_location.join(':')
+      auto_include_context.preloaded(self, cache_name: cache_name, key: key, &block)
     end
   end
   ::ActiveRecord::Base.include(::Goldiloader::BasePatch)

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -25,6 +25,10 @@ module Goldiloader
       @auto_include_context = nil
       super
     end
+
+    def goldiload(name, primary_key: :id, &block)
+      auto_include_context.preloaded(self, name, primary_key: primary_key, &block)
+    end
   end
   ::ActiveRecord::Base.include(::Goldiloader::BasePatch)
 

--- a/lib/goldiloader/auto_include_context.rb
+++ b/lib/goldiloader/auto_include_context.rb
@@ -51,5 +51,7 @@ module Goldiloader
     end
 
     alias_method :register_model, :register_models
+
+    include Goldiloader::CustomPreloads
   end
 end

--- a/lib/goldiloader/auto_include_context.rb
+++ b/lib/goldiloader/auto_include_context.rb
@@ -52,6 +52,6 @@ module Goldiloader
 
     alias_method :register_model, :register_models
 
-    include Goldiloader::CustomPreloads
+    prepend Goldiloader::CustomPreloads
   end
 end

--- a/lib/goldiloader/custom_preloads.rb
+++ b/lib/goldiloader/custom_preloads.rb
@@ -15,8 +15,10 @@ module Goldiloader
 
         # We're using instance_exec instead of a simple yield to make sure that the
         # given block does not have any references to the model instance as this might
-        # lead to unexpected results
-        preloaded_hash = instance_exec(ids, &block)
+        # lead to unexpected results. The block will be executed in the context of the
+        # class of the model instead.
+        block_context = models.first.class
+        preloaded_hash = block_context.instance_exec(ids, &block)
         store_preloaded(cache_name, preloaded_hash)
       end
       fetch_preloaded(cache_name, model, key: key)

--- a/lib/goldiloader/custom_preloads.rb
+++ b/lib/goldiloader/custom_preloads.rb
@@ -2,28 +2,35 @@
 
 module Goldiloader
   module CustomPreloads
-    def preloaded(instance, key, primary_key: :id, &_block)
-      unless preloaded?(key)
+    def initialize
+      super
+      @custom_preloads = nil
+    end
+
+    def preloaded(model, cache_name:, key:, &_block)
+      unless preloaded?(cache_name)
         ids = models.map do |record|
-          record.public_send(primary_key)
+          record.public_send(key)
         end
 
-        store_preloaded(key, yield(ids))
+        store_preloaded(cache_name, yield(ids))
       end
-      fetch_preloaded(key, instance, primary_key: primary_key)
+      fetch_preloaded(cache_name, model, key: key)
     end
 
-    def store_preloaded(key, preloads_hash)
+    private
+
+    def store_preloaded(cache_name, preloaded_hash)
       @custom_preloads ||= {}
-      @custom_preloads[key] = preloads_hash
+      @custom_preloads[cache_name] = preloaded_hash
     end
 
-    def fetch_preloaded(key, instance, primary_key: :id)
-      @custom_preloads&.dig(key, instance.public_send(primary_key))
+    def fetch_preloaded(cache_name, instance, key:)
+      @custom_preloads&.dig(cache_name, instance.public_send(key))
     end
 
-    def preloaded?(key)
-      @custom_preloads&.key?(key)
+    def preloaded?(cache_name)
+      @custom_preloads&.key?(cache_name)
     end
   end
 end

--- a/lib/goldiloader/custom_preloads.rb
+++ b/lib/goldiloader/custom_preloads.rb
@@ -14,16 +14,16 @@ module Goldiloader
     end
 
     def store_preloaded(key, preloads_hash)
-      @preloads ||= {}
-      @preloads[key] = preloads_hash
+      @custom_preloads ||= {}
+      @custom_preloads[key] = preloads_hash
     end
 
     def fetch_preloaded(key, instance, primary_key: :id)
-      @preloads&.dig(key, instance.public_send(primary_key))
+      @custom_preloads&.dig(key, instance.public_send(primary_key))
     end
 
     def preloaded?(key)
-      @preloads&.key?(key)
+      @custom_preloads&.key?(key)
     end
   end
 end

--- a/lib/goldiloader/custom_preloads.rb
+++ b/lib/goldiloader/custom_preloads.rb
@@ -7,13 +7,17 @@ module Goldiloader
       @custom_preloads = nil
     end
 
-    def preloaded(model, cache_name:, key:, &_block)
+    def preloaded(model, cache_name:, key:, &block)
       unless preloaded?(cache_name)
         ids = models.map do |record|
           record.public_send(key)
         end
 
-        store_preloaded(cache_name, yield(ids))
+        # We're using instance_exec instead of a simple yield to make sure that the
+        # given block does not have any references to the model instance as this might
+        # lead to unexpected results
+        preloaded_hash = instance_exec(ids, &block)
+        store_preloaded(cache_name, preloaded_hash)
       end
       fetch_preloaded(cache_name, model, key: key)
     end

--- a/lib/goldiloader/custom_preloads.rb
+++ b/lib/goldiloader/custom_preloads.rb
@@ -2,13 +2,13 @@
 
 module Goldiloader
   module CustomPreloads
-    def preloaded(instance, key, primary_key: :id, &block)
+    def preloaded(instance, key, primary_key: :id, &_block)
       unless preloaded?(key)
         ids = models.map do |record|
           record.public_send(primary_key)
         end
 
-        store_preloaded(key, block.call(ids))
+        store_preloaded(key, yield(ids))
       end
       fetch_preloaded(key, instance, primary_key: primary_key)
     end

--- a/lib/goldiloader/custom_preloads.rb
+++ b/lib/goldiloader/custom_preloads.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Goldiloader
+  module CustomPreloads
+    def preloaded(instance, key, primary_key: :id, &block)
+      unless preloaded?(key)
+        ids = models.map do |record|
+          record.public_send(primary_key)
+        end
+
+        store_preloaded(key, block.call(ids))
+      end
+      fetch_preloaded(key, instance, primary_key: primary_key)
+    end
+
+    def store_preloaded(key, preloads_hash)
+      @preloads ||= {}
+      @preloads[key] = preloads_hash
+    end
+
+    def fetch_preloaded(key, instance, primary_key: :id)
+      @preloads&.dig(key, instance.public_send(primary_key))
+    end
+
+    def preloaded?(key)
+      @preloads&.key?(key)
+    end
+  end
+end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -123,9 +123,9 @@ class Blog < ActiveRecord::Base
 
   def custom_preload_with_self_reference
     goldiload do |ids|
-      ids.to_h {|id|
-        [id, self.posts.count]
-      }
+      ids.to_h do |id|
+        [id, posts.count]
+      end
     end
   end
 

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -106,8 +106,18 @@ class Blog < ActiveRecord::Base
   has_one :post_with_order, -> { order(:id) }, class_name: 'Post'
 
   def posts_count
-    goldiload(:posts_count) do |ids|
+    goldiload do |ids|
       Post.where(blog_id: ids).group(:blog_id).count
+    end
+  end
+
+  def tags_count
+    goldiload do |ids|
+      Tag
+        .joins(:posts)
+        .where(posts: { blog_id: ids })
+        .group(:blog_id)
+        .count
     end
   end
 

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -121,13 +121,15 @@ class Blog < ActiveRecord::Base
     end
   end
 
+  # rubocop:disable Style/RedundantSelf
   def custom_preload_with_self_reference
     goldiload do |ids|
       ids.to_h do |id|
-        [id, posts.count]
+        [id, self.posts.count]
       end
     end
   end
+  # rubocop:enable Style/RedundantSelf
 
   def posts_overridden
     'boom'

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -105,6 +105,12 @@ class Blog < ActiveRecord::Base
 
   has_one :post_with_order, -> { order(:id) }, class_name: 'Post'
 
+  def posts_count
+    goldiload(:posts_count) do |ids|
+      Post.where(blog_id: ids).group(:blog_id).count
+    end
+  end
+
   def posts_overridden
     'boom'
   end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -121,6 +121,14 @@ class Blog < ActiveRecord::Base
     end
   end
 
+  def custom_preload_with_self_reference
+    goldiload do |ids|
+      ids.to_h {|id|
+        [id, self.posts.count]
+      }
+    end
+  end
+
   def posts_overridden
     'boom'
   end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -154,6 +154,18 @@ class Post < ActiveRecord::Base
 
   after_destroy :after_post_destroy
 
+  def author_global_id
+    author&.to_gid&.to_s
+  end
+
+  def author_via_global_id
+    goldiload key: :author_global_id do |gids|
+      GlobalID::Locator.locate_many(gids).index_by do |author|
+        author.to_gid.to_s
+      end
+    end
+  end
+
   def after_post_destroy
     # Hook for tests
   end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -1007,6 +1007,12 @@ describe Goldiloader do
       expect(blog1.posts_count).to eq blog1.posts.count
       expect(blog2.posts_count).to eq blog2.posts.count
     end
+
+    it "prevents self references to the model inside the block" do
+      expect {
+        blog1.custom_preload_with_self_reference
+      }.to raise_error(NoMethodError)
+    end
   end
 
   describe "#globally_enabled" do

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -1009,9 +1009,9 @@ describe Goldiloader do
     end
 
     it "prevents self references to the model inside the block" do
-      expect {
+      expect do
         blog1.custom_preload_with_self_reference
-      }.to raise_error(NoMethodError)
+      end.to raise_error(NoMethodError)
     end
   end
 

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -1016,12 +1016,12 @@ describe Goldiloader do
 
     it "uses different caches for different blocks" do
       result1 = blog1.goldiload do |ids|
-        ids.to_h {|id| [id, 42] }
+        ids.to_h { |id| [id, 42] }
       end
       expect(result1).to eq 42
 
       result2 = blog1.goldiload do |ids|
-        ids.to_h {|id| [id, 666] }
+        ids.to_h { |id| [id, 666] }
       end
       expect(result2).to eq 666
     end
@@ -1029,13 +1029,13 @@ describe Goldiloader do
     it "can use an explicit cache_name" do
       # Define explicit cache key :random_cache_key
       blog1.goldiload(:random_cache_key) do |ids|
-        ids.to_h {|id| [id, 42] }
+        ids.to_h { |id| [id, 42] }
       end
 
       # Another blog for the same key
       result = blog1.goldiload(:random_cache_key) do |ids|
         # :nocov:
-        ids.to_h {|id| [id, 666] }
+        ids.to_h { |id| [id, 666] }
         # :nocov:
       end
 

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -994,7 +994,7 @@ describe Goldiloader do
       end
 
       expected_tag_counts = blogs.map do |blog|
-        blog.posts.sum {|post| post.tags.count }
+        blog.posts.sum { |post| post.tags.count }
       end
 
       expect do

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -978,6 +978,24 @@ describe Goldiloader do
     end
   end
 
+  context "custom preloads" do
+    before do
+      blog1.posts.create(title: 'another-post')
+    end
+
+    let(:blogs) { Blog.order(:name).to_a }
+
+    it "returns custom preloads" do
+      expected_values = blogs.map {|blog|
+        blog.posts.count
+      }
+
+      expect do
+        expect(blogs.map(&:posts_count)).to eq expected_values
+      end.to execute_queries(Post => 1)
+    end
+  end
+
   describe "#globally_enabled" do
     context "enabled" do
       it "allows setting per thread" do

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -986,9 +986,9 @@ describe Goldiloader do
     let(:blogs) { Blog.order(:name).to_a }
 
     it "returns custom preloads" do
-      expected_values = blogs.map {|blog|
+      expected_values = blogs.map do |blog|
         blog.posts.count
-      }
+      end
 
       expect do
         expect(blogs.map(&:posts_count)).to eq expected_values

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ RSpec::Matchers.define(:execute_queries) do |expected_counts|
 
     expected_counts_by_table = expected_counts.transform_keys(&:table_name)
 
-    table_extractor = /SELECT .* FROM "(.+)" WHERE/
+    table_extractor = /SELECT .* FROM "(\w+)" (WHERE|INNER JOIN)/
     actual_counts_by_table = @actual_queries.group_by do |query|
       table_extractor.match(query)[1]
     end.transform_values(&:size)


### PR DESCRIPTION
Referenced Issue: #128 

This PR implements the idea that I outlined in the mentioned issue. 
I was thinking of moving the logic into its own class (e.g. `auto_include_context.custom_preloads.some_method`), but that would require to also pass the `@models` to that instance. So I ended up including the logic in the `AutoIncludeContext` to keep the memory footprint as low as possible.

Refer to the Readme changes for usage instructions. Please let me know if there's anything should be adjusted (code styling etc.).