### PR TITLE
Custom preloads with multiple keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,9 @@ class Meeting < ActiveRecord::Base
       #   [<organizer_id_2>, <room_id_2>]
       # ]
       notes = logic_for_fetching_organizer_notes
-      notes.group_by {|report|
+      notes.group_by do |report|
         [report.organizer_id, report.room_id]
-      }
+      end
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -328,6 +328,28 @@ class Post < ActiveRecord::Base
 end
 ```
 
+If you want to preload something that is based on multiple keys, you can also pass an array:
+
+```ruby
+class Meeting < ActiveRecord::Base
+  def organizer_notes
+    goldiload(key: [:organizer_id, :room_id]) do |id_sets|
+      # +id_sets+ will be a two dimensional array with the
+      # organizer_id and room_id for each item, e.g.
+      # [
+      #   [<organizer_id_1>, <room_id_1>],
+      #   [<organizer_id_2>, <room_id_2>]
+      # ]
+      notes = logic_for_fetching_organizer_notes
+      notes.group_by {|report|
+        [report.organizer_id, report.room_id]
+      }
+    end
+  end
+end
+```
+
+
 **Note:** The `goldiload` method will use the `source_location` of the given block as a cache name to distinguish between multiple defined preloads. If this causes an issue for you, you can also pass a cache name explicitly as the first argument to the `goldiload` method.
 
 

--- a/lib/goldiloader/custom_preloads.rb
+++ b/lib/goldiloader/custom_preloads.rb
@@ -29,9 +29,9 @@ module Goldiloader
     def key_from_record(record, key_or_key_list)
       if key_or_key_list.is_a?(Array)
         # allow passing an array of keys that will be collected from the record
-        key_or_key_list.map {|key|
+        key_or_key_list.map do |key|
           record.public_send(key)
-        }
+        end
       else
         record.public_send(key_or_key_list)
       end

--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -1051,6 +1051,21 @@ describe Goldiloader do
         expect(posts.map(&:author_via_global_id)).to eq expected_authors
       end.to execute_queries(User => 1)
     end
+
+    it "can use an array as key argument" do
+      yielded_values = nil
+      result = blog1.goldiload(key: [:id, :name]) do |key_set|
+        yielded_values = key_set
+        key_set.to_h do |keys|
+          [keys, 123]
+        end
+      end
+
+      expect(yielded_values).to eq [
+        [blog1.id, blog1.name]
+      ]
+      expect(result).to eq 123
+    end
   end
 
   describe "#globally_enabled" do


### PR DESCRIPTION
Hi,

the idea of this PR is to allow custom preloads with multiple keys without adding a dedicated method for the the combined key.

In order to do so, you can just pass an array of symbols as the `key:` argument. Instead of passing a plain array of ids to the block, we would collect an array of keys for each record and pass the 2 dimensional array to the block.

This is 100% backwards compatible.