### PR TITLE
Add Rails 7.1 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
               gemfile:
                 - gemfiles/rails_6.1.gemfile
                 - gemfiles/rails_7.0.gemfile
+                - gemfiles/rails_7.1.gemfile
                 - gemfiles/rails_edge.gemfile
               ruby_version:
                 - 3.0.6

--- a/Appraisals
+++ b/Appraisals
@@ -13,9 +13,9 @@ appraise 'rails-7.0' do
 end
 
 appraise 'rails-7.1' do
-  gem 'activerecord', '7.1.0'
-  gem 'activesupport', '7.1.0'
-  gem 'rails', '7.1.0'
+  gem 'activerecord', '7.1.3'
+  gem 'activesupport', '7.1.3'
+  gem 'rails', '7.1.3'
 end
 
 appraise 'rails-edge' do

--- a/README.md
+++ b/README.md
@@ -215,8 +215,6 @@ Associations with any of the following options cannot be eager loaded:
 * `limit`
 * `offset`
 * `finder_sql`
-* `group` (only applies to Rails < 5.0.7 and Rails 5.1.x < 5.1.5 due to a [Rails bug](https://github.com/rails/rails/issues/15854))
-* `from` (only applies to Rails < 5.0.7 and Rails 5.1.x < 5.1.5 due to a Rails bug)
 
 Goldiloader detects associations with any of these options and disables automatic eager loading on them.
 
@@ -377,7 +375,7 @@ end
 
 ## Status
 
-This gem is tested with Rails 6.1, 7.0 and Edge using MRI 3.0, 3.1 and 3.2. 
+This gem is tested with Rails 6.1, 7.0, 7.1, and Edge using MRI 3.0, 3.1, 3.2, and 3.3. 
 
 Let us know if you find any issues or have any other feedback.
 

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "7.1.0"
-gem "activesupport", "7.1.0"
-gem "rails", "7.1.0"
+gem "activerecord", "7.1.3"
+gem "activesupport", "7.1.3"
+gem "rails", "7.1.3"
 
 gemspec path: "../"


### PR DESCRIPTION
I forgot to actually add Rails 7.1 to the test matrix in #127 🤦‍♂️

While I was in here I removed some references to older versions of Rails in the README.

@erikkessler1 - you're prime