### PR TITLE
Auto include through associations when 'middle' association was loaded but not modified

### DIFF
--- a/spec/goldiloader/goldiloader_spec.rb
+++ b/spec/goldiloader/goldiloader_spec.rb
@@ -573,6 +573,48 @@ describe Goldiloader do
     end
   end
 
+  context "when the 'middle' part of a has_many through association was already loaded to memory and not modified" do
+    let!(:posts) { Post.order(:title).to_a }
+    let(:post) { posts.first }
+    let(:other_post) { posts.last }
+
+    before do
+      post.post_tags.to_a
+    end
+
+    it "auto eager loads the association when accessing a peer" do
+      other_post.tags.to_a
+      expect(post.association(:tags)).to be_loaded
+    end
+
+    it "doesn't reload the already loaded models when accessing a peer" do
+      object_ids = post.post_tags.map(&:object_id)
+      other_post.tags.to_a
+      expect(post.post_tags.map(&:object_id)).to eq(object_ids)
+    end
+  end
+
+  context "when the 'middle' part of a has_many through association was already loaded to memory and modified" do
+    let!(:posts) { Post.order(:title).to_a }
+    let(:post) { posts.first }
+    let(:other_post) { posts.last }
+
+    before do
+      post.post_tags.to_a.first.tag = child_tag3
+    end
+
+    it "doesn't auto eager loads the association when accessing a peer" do
+      other_post.tags.to_a
+      expect(post.association(:tags)).not_to be_loaded
+    end
+
+    it "doesn't reload the already loaded models when accessing a peer" do
+      object_ids = post.post_tags.map(&:object_id)
+      other_post.tags.to_a
+      expect(post.post_tags.map(&:object_id)).to eq(object_ids)
+    end
+  end
+
   context "when a has_many through association has in-memory changes" do
     let!(:posts) { Post.order(:title).to_a }
     let(:post) { posts.first }


### PR DESCRIPTION
When an association goes through another association, e.g. `has_many :tags, through: :post_tags`, loading the `post_tags` association was enough, to not auto include the `tags` association when it is first accessed.
This is correct for when the `post_tags` association was modified and auto include could lead to weird results. When nothing was modified it is totally fine to auto include the through association.

Consider the following data model and data:

```ruby
class Post < ActiveRecord::Base
  has_many :post_tags
  has_many :tags, through: :post_tags
end

class PostTags < ActiveRecord::Base
  belongs_to :post
  belongs_to :tag
end

class Tags < ActiveRecord::Base
  has_many :post_tags
  has_many :posts, through: :post_tags
end

blog = Blog.create!(name: 'blog')

post1 = Post.create(blog: blog, title: 'post1')
post2 = Post.create(blog: blog, title: 'post2')

tag1 = Tags.create(name: 'tag1')
tag2 = Tags.create(name: 'tag2')

PostTags.create(post: post1, tag: tag1)
PostTags.create(post: post1, tag: tag2)

PostTags.create(post: post2, tag: tag1)
PostTags.create(post: post2, tag: tag2)
```

Then auto include does not work when the middle association is accessed first, although it is not modified.

```ruby
posts = Post.order(:title).to_a
post1 = posts.first
post2 = posts.last

post1.post_tags.to_a # load the "middle" association
post2.tags.to_a # load the through association

# Is false but should be true
post1.association(:tags).loaded? # => false
```
