### PR TITLE
Use ActiveRecord lazy load hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.2.2
+- Fix [issue 140](https://github.com/salsify/goldiloader/issues/140) - Defer referencing ActiveRecord classes until 
+  it's been initialized to ensure the `Rails.application.config.filter_parameters` setting is applied properly.
+  **Thanks [GuillouuH](https://github.com/GuillouuH)**
+
 ## 5.2.1
 - Auto include associations when the through association has already been loaded. See
   [138](https://github.com/salsify/goldiloader/pull/138) for details.

--- a/lib/goldiloader.rb
+++ b/lib/goldiloader.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
 require 'active_support/all'
-# require 'active_record'
 require 'goldiloader/compatibility'
 require 'goldiloader/custom_preloads'
 require 'goldiloader/auto_include_context'
 require 'goldiloader/scope_info'
 require 'goldiloader/association_options'
 require 'goldiloader/association_loader'
-require 'goldiloader/active_record_patches'
+
+ActiveSupport.on_load(:active_record) do
+  # Defer referencing ActiveRecord class until it's loaded
+  # See https://github.com/rails/rails/issues/48704
+  require 'goldiloader/active_record_patches'
+end
 
 module Goldiloader
   class << self

--- a/lib/goldiloader.rb
+++ b/lib/goldiloader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/all'
-require 'active_record'
+# require 'active_record'
 require 'goldiloader/compatibility'
 require 'goldiloader/custom_preloads'
 require 'goldiloader/auto_include_context'

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -31,9 +31,7 @@ module Goldiloader
       auto_include_context.preloaded(self, cache_name: cache_name, key: key, &block)
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ::ActiveRecord::Base.include(::Goldiloader::BasePatch)
-  end
+  ::ActiveRecord::Base.include(::Goldiloader::BasePatch)
 
   module RelationPatch
     def exec_queries
@@ -62,9 +60,7 @@ module Goldiloader
       @values[:auto_include] = value
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ::ActiveRecord::Relation.prepend(::Goldiloader::RelationPatch)
-  end
+  ::ActiveRecord::Relation.prepend(::Goldiloader::RelationPatch)
 
   module MergerPatch
     private
@@ -74,9 +70,7 @@ module Goldiloader
       super
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ActiveRecord::Relation::Merger.prepend(::Goldiloader::MergerPatch)
-  end
+  ActiveRecord::Relation::Merger.prepend(::Goldiloader::MergerPatch)
 
   module AssociationReflectionPatch
     # Note we need to pass the association's target class as an argument since it won't be known
@@ -101,10 +95,8 @@ module Goldiloader
       @eager_loadable_cache[target_klass]
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ActiveRecord::Reflection::AssociationReflection.include(::Goldiloader::AssociationReflectionPatch)
-    ActiveRecord::Reflection::ThroughReflection.include(::Goldiloader::AssociationReflectionPatch)
-  end
+  ActiveRecord::Reflection::AssociationReflection.include(::Goldiloader::AssociationReflectionPatch)
+  ActiveRecord::Reflection::ThroughReflection.include(::Goldiloader::AssociationReflectionPatch)
 
   module AssociationPatch
     extend ActiveSupport::Concern
@@ -151,9 +143,7 @@ module Goldiloader
       end
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ::ActiveRecord::Associations::Association.include(::Goldiloader::AssociationPatch)
-  end
+  ::ActiveRecord::Associations::Association.include(::Goldiloader::AssociationPatch)
 
   module SingularAssociationPatch
     private
@@ -162,9 +152,7 @@ module Goldiloader
       load_with_auto_include { super }
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ::ActiveRecord::Associations::SingularAssociation.prepend(::Goldiloader::SingularAssociationPatch)
-  end
+  ::ActiveRecord::Associations::SingularAssociation.prepend(::Goldiloader::SingularAssociationPatch)
 
   module CollectionAssociationPatch
     # Force these methods to load the entire association for fully_load associations
@@ -183,9 +171,7 @@ module Goldiloader
       fully_load? || super
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ::ActiveRecord::Associations::CollectionAssociation.prepend(::Goldiloader::CollectionAssociationPatch)
-  end
+  ::ActiveRecord::Associations::CollectionAssociation.prepend(::Goldiloader::CollectionAssociationPatch)
 
   module ThroughAssociationPatch
     def auto_include?
@@ -207,10 +193,8 @@ module Goldiloader
       end
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ::ActiveRecord::Associations::HasManyThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
-    ::ActiveRecord::Associations::HasOneThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
-  end
+  ::ActiveRecord::Associations::HasManyThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
+  ::ActiveRecord::Associations::HasOneThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
 
   module CollectionProxyPatch
     # The CollectionProxy just forwards exists? to the underlying scope so we need to intercept this and
@@ -226,7 +210,7 @@ module Goldiloader
       end
     end
   end
-  ActiveSupport.on_load(:active_record) do
-    ::ActiveRecord::Associations::CollectionProxy.prepend(::Goldiloader::CollectionProxyPatch)
-  end
+  ::ActiveRecord::Associations::CollectionProxy.prepend(::Goldiloader::CollectionProxyPatch)
 end
+
+Goldiloader::AssociationOptions.register

--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -31,7 +31,9 @@ module Goldiloader
       auto_include_context.preloaded(self, cache_name: cache_name, key: key, &block)
     end
   end
-  ::ActiveRecord::Base.include(::Goldiloader::BasePatch)
+  ActiveSupport.on_load(:active_record) do
+    ::ActiveRecord::Base.include(::Goldiloader::BasePatch)
+  end
 
   module RelationPatch
     def exec_queries
@@ -60,7 +62,9 @@ module Goldiloader
       @values[:auto_include] = value
     end
   end
-  ::ActiveRecord::Relation.prepend(::Goldiloader::RelationPatch)
+  ActiveSupport.on_load(:active_record) do
+    ::ActiveRecord::Relation.prepend(::Goldiloader::RelationPatch)
+  end
 
   module MergerPatch
     private
@@ -70,7 +74,9 @@ module Goldiloader
       super
     end
   end
-  ActiveRecord::Relation::Merger.prepend(::Goldiloader::MergerPatch)
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::Relation::Merger.prepend(::Goldiloader::MergerPatch)
+  end
 
   module AssociationReflectionPatch
     # Note we need to pass the association's target class as an argument since it won't be known
@@ -95,8 +101,10 @@ module Goldiloader
       @eager_loadable_cache[target_klass]
     end
   end
-  ActiveRecord::Reflection::AssociationReflection.include(::Goldiloader::AssociationReflectionPatch)
-  ActiveRecord::Reflection::ThroughReflection.include(::Goldiloader::AssociationReflectionPatch)
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::Reflection::AssociationReflection.include(::Goldiloader::AssociationReflectionPatch)
+    ActiveRecord::Reflection::ThroughReflection.include(::Goldiloader::AssociationReflectionPatch)
+  end
 
   module AssociationPatch
     extend ActiveSupport::Concern
@@ -143,7 +151,9 @@ module Goldiloader
       end
     end
   end
-  ::ActiveRecord::Associations::Association.include(::Goldiloader::AssociationPatch)
+  ActiveSupport.on_load(:active_record) do
+    ::ActiveRecord::Associations::Association.include(::Goldiloader::AssociationPatch)
+  end
 
   module SingularAssociationPatch
     private
@@ -152,7 +162,9 @@ module Goldiloader
       load_with_auto_include { super }
     end
   end
-  ::ActiveRecord::Associations::SingularAssociation.prepend(::Goldiloader::SingularAssociationPatch)
+  ActiveSupport.on_load(:active_record) do
+    ::ActiveRecord::Associations::SingularAssociation.prepend(::Goldiloader::SingularAssociationPatch)
+  end
 
   module CollectionAssociationPatch
     # Force these methods to load the entire association for fully_load associations
@@ -171,7 +183,9 @@ module Goldiloader
       fully_load? || super
     end
   end
-  ::ActiveRecord::Associations::CollectionAssociation.prepend(::Goldiloader::CollectionAssociationPatch)
+  ActiveSupport.on_load(:active_record) do
+    ::ActiveRecord::Associations::CollectionAssociation.prepend(::Goldiloader::CollectionAssociationPatch)
+  end
 
   module ThroughAssociationPatch
     def auto_include?
@@ -193,8 +207,10 @@ module Goldiloader
       end
     end
   end
-  ::ActiveRecord::Associations::HasManyThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
-  ::ActiveRecord::Associations::HasOneThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
+  ActiveSupport.on_load(:active_record) do
+    ::ActiveRecord::Associations::HasManyThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
+    ::ActiveRecord::Associations::HasOneThroughAssociation.prepend(::Goldiloader::ThroughAssociationPatch)
+  end
 
   module CollectionProxyPatch
     # The CollectionProxy just forwards exists? to the underlying scope so we need to intercept this and
@@ -210,5 +226,7 @@ module Goldiloader
       end
     end
   end
-  ::ActiveRecord::Associations::CollectionProxy.prepend(::Goldiloader::CollectionProxyPatch)
+  ActiveSupport.on_load(:active_record) do
+    ::ActiveRecord::Associations::CollectionProxy.prepend(::Goldiloader::CollectionProxyPatch)
+  end
 end

--- a/lib/goldiloader/association_options.rb
+++ b/lib/goldiloader/association_options.rb
@@ -23,4 +23,6 @@ module Goldiloader
   end
 end
 
-Goldiloader::AssociationOptions.register
+ActiveSupport.on_load(:active_record) do
+  Goldiloader::AssociationOptions.register
+end

--- a/lib/goldiloader/association_options.rb
+++ b/lib/goldiloader/association_options.rb
@@ -22,7 +22,3 @@ module Goldiloader
     end
   end
 end
-
-ActiveSupport.on_load(:active_record) do
-  Goldiloader::AssociationOptions.register
-end

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -2,8 +2,6 @@
 
 module Goldiloader
   module Compatibility
-    ACTIVE_RECORD_VERSION = ::Gem::Version.new(::ActiveRecord::VERSION::STRING).release
-
     def self.pre_rails_7?
       ::ActiveRecord::VERSION::MAJOR < 7
     end

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goldiloader
-  VERSION = '5.2.1'
+  VERSION = '5.2.2'
 end


### PR DESCRIPTION
This PR defers referencing any ActiveRecord classes until the framework has been initialized to ensure the `Rails.application.config.filter_parameters` setting is applied properly. Unfortunately our usage of [combustion](https://github.com/pat/combustion) makes it impossible to add automated test coverage but I've manually verified the fix using https://github.com/jturkel/rails-test-app.

Fixes #140

prime: @erikkessler1 