### PR TITLE
Enable testing Rails 8.0

### DIFF
--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -31,19 +31,19 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 7.2'
-  spec.add_dependency 'activesupport', '>= 6.1', '< 7.2'
+  spec.add_dependency 'activerecord', '>= 6.1', '< 8.1'
+  spec.add_dependency 'activesupport', '>= 6.1', '< 8.1'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'combustion', '~> 1.3'
   spec.add_development_dependency 'coveralls_reborn', '>= 0.18.0'
-  spec.add_development_dependency 'rails', '>= 6.1', '< 7.2'
+  spec.add_development_dependency 'rails', '>= 6.1', '< 8.1'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.4'
 end


### PR DESCRIPTION
Rails recently bumped their `main` version number to 8.0 so we need to tweak the gemspec for testing against Rails edge. CI was having some issues with sqlite3 2.0 so I pinned this to 1.x for now.

@erikkessler1 - you're prime 