### PR TITLE
Use assert_modifiable! rather than assert_mutability! in Rails 7.2+.

### DIFF
--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -56,7 +56,11 @@ module Goldiloader
     end
 
     def auto_include_value=(value)
-      assert_mutability!
+      if ::Goldiloader::Compatibility.pre_rails_7_2?
+        assert_mutability!
+      else
+        assert_modifiable!
+      end
       @values[:auto_include] = value
     end
   end

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -13,5 +13,10 @@ module Goldiloader
     def self.rails_6_1_or_greater?
       ::ActiveRecord::VERSION::MAJOR > 6 || rails_6_1?
     end
+
+    def self.pre_rails_7_2?
+      ::ActiveRecord::VERSION::MAJOR < 7 ||
+        (::ActiveRecord::VERSION::MAJOR == 7 && ::ActiveRecord::VERSION::MINOR < 2)
+    end
   end
 end


### PR DESCRIPTION
Rails renamed `assert_mutability!` to `assert_modifiable!` in https://github.com/rails/rails/pull/52320 so we need to make a small goldiloader change to get Rails edge builds passing again.

prime: @erikkessler1 