### PR TITLE
Official Rails 7.2.0 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,7 @@ jobs:
       - checkout
       - unless:
           condition:
-            or:
-              - equal: ["gemfiles/rails_7.2.gemfile", << parameters.gemfile >>]
-              - equal: ["gemfiles/rails_edge.gemfile", << parameters.gemfile >>]
+            equal: ["gemfiles/rails_edge.gemfile", << parameters.gemfile >>]
           steps:
             - restore_cache:
                 keys:
@@ -58,9 +56,7 @@ jobs:
             fi
       - unless:
           condition:
-            or:
-              - equal: [ "gemfiles/rails_7.2.gemfile", << parameters.gemfile >> ]
-              - equal: [ "gemfiles/rails_edge.gemfile", << parameters.gemfile >> ]
+            equal: [ "gemfiles/rails_edge.gemfile", << parameters.gemfile >> ]
           steps:
             - save_cache:
                 key: v1-gems-ruby-<< parameters.ruby_version >>-{{ checksum "goldiloader.gemspec" }}-{{ checksum "<< parameters.gemfile >>" }}
@@ -109,7 +105,6 @@ workflows:
           matrix:
             parameters:
               gemfile:
-                - gemfiles/rails_7.2.gemfile
                 - gemfiles/rails_edge.gemfile
               ruby_version:
                 - 3.3.4

--- a/Appraisals
+++ b/Appraisals
@@ -19,10 +19,9 @@ appraise 'rails-7.1' do
 end
 
 appraise 'rails-7.2' do
-  # TODO: Update to 7.2.0 once it's released
-  gem 'activerecord', github: 'rails/rails', branch: '7-2-stable'
-  gem 'activesupport', github: 'rails/rails', branch: '7-2-stable'
-  gem 'rails', github: 'rails/rails', branch: '7-2-stable'
+  gem 'activerecord', '7.2.0'
+  gem 'activesupport', '7.2.0'
+  gem 'rails', '7.2.0'
 end
 
 appraise 'rails-edge' do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.3.0
+- Add support for Rails 7.2.
+
 ## 5.2.2
 - Fix [issue 140](https://github.com/salsify/goldiloader/issues/140) - Defer referencing ActiveRecord classes until 
   it's been initialized to ensure the `Rails.application.config.filter_parameters` setting is applied properly.

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", branch: "7-2-stable", git: "https://github.com/rails/rails.git"
-gem "activesupport", branch: "7-2-stable", git: "https://github.com/rails/rails.git"
-gem "rails", branch: "7-2-stable", git: "https://github.com/rails/rails.git"
+gem "activerecord", "7.2.0"
+gem "activesupport", "7.2.0"
+gem "rails", "7.2.0"
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'activerecord', '>= 6.1', '< 8.1'
-  spec.add_dependency 'activesupport', '>= 6.1', '< 8.1'
+  spec.add_dependency 'activerecord', '>= 6.1', '< 8'
+  spec.add_dependency 'activesupport', '>= 6.1', '< 8'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'

--- a/lib/goldiloader/version.rb
+++ b/lib/goldiloader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Goldiloader
-  VERSION = '5.2.2'
+  VERSION = '5.3.0'
 end


### PR DESCRIPTION
This PR releases official support for Rails 7.2. Also following the suggestion of @kyrofa in #154, I changed the gemspec Rails version constraint to `< 8` so we can test against `8.0.0.alpha` on `main` without claiming support `8.0.0`.

@erikkessler1 - you're prime