### PR TITLE
Test against sqlite3 2.0 for Rails 7.2+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,14 @@ jobs:
   lint:
     docker:
       - image: ruby:3.0.7
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails_6.1.gemfile
     working_directory: ~/goldiloader
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-3.0.7-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
+            - v1-gems-ruby-3.0.7-{{ checksum "goldiloader.gemspec" }}-{{ checksum "gemfiles/rails_6.1.gemfile" }}
             - v1-gems-ruby-3.0.7-
       - run:
           name: Install Gems
@@ -18,7 +20,7 @@ jobs:
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-3.0.7-{{ checksum "goldiloader.gemspec" }}-{{ checksum "Gemfile" }}
+          key: v1-gems-ruby-3.0.7-{{ checksum "goldiloader.gemspec" }}-{{ checksum "gemfiles/rails_6.1.gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"

--- a/Appraisals
+++ b/Appraisals
@@ -4,18 +4,21 @@ appraise 'rails-6.1' do
   gem 'activerecord', '6.1.7.8'
   gem 'activesupport', '6.1.7.8'
   gem 'rails', '6.1.7.8'
+  gem 'sqlite3', '~> 1.7'
 end
 
 appraise 'rails-7.0' do
   gem 'activerecord', '7.0.8.4'
   gem 'activesupport', '7.0.8.4'
   gem 'rails', '7.0.8.4'
+  gem 'sqlite3', '~> 1.7'
 end
 
 appraise 'rails-7.1' do
   gem 'activerecord', '7.1.3.4'
   gem 'activesupport', '7.1.3.4'
   gem 'rails', '7.1.3.4'
+  gem 'sqlite3', '~> 1.7'
 end
 
 appraise 'rails-7.2' do

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "6.1.7.8"
 gem "activesupport", "6.1.7.8"
 gem "rails", "6.1.7.8"
+gem "sqlite3", "~> 1.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "7.0.8.4"
 gem "activesupport", "7.0.8.4"
 gem "rails", "7.0.8.4"
+gem "sqlite3", "~> 1.7"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "7.1.3.4"
 gem "activesupport", "7.1.3.4"
 gem "rails", "7.1.3.4"
+gem "sqlite3", "~> 1.7"
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -45,5 +45,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'salsify_rubocop', '~> 1.0.1'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3', '~> 1.4'
+  spec.add_development_dependency 'sqlite3', '~> 2.0'
 end


### PR DESCRIPTION
Rails 7.2 added support for sqlite3 2.x. Rails 8.0 will require sqlite3 2.x. This PR updates our test configuration to reflect that which will fix the failing Rails edge tests.