### PR TITLE
Remove dead code for old Rails versions

### DIFF
--- a/lib/goldiloader/active_record_patches.rb
+++ b/lib/goldiloader/active_record_patches.rb
@@ -56,11 +56,7 @@ module Goldiloader
     end
 
     def auto_include_value=(value)
-      if ::Goldiloader::Compatibility.pre_rails_7_2?
-        assert_mutability!
-      else
-        assert_modifiable!
-      end
+      assert_modifiable!
       @values[:auto_include] = value
     end
   end

--- a/lib/goldiloader/association_loader.rb
+++ b/lib/goldiloader/association_loader.rb
@@ -15,11 +15,7 @@ module Goldiloader
     private
 
     def eager_load(models, association_name)
-      if Goldiloader::Compatibility.pre_rails_7?
-        ::ActiveRecord::Associations::Preloader.new.preload(models, [association_name])
-      else
-        ::ActiveRecord::Associations::Preloader.new(records: models, associations: [association_name]).call
-      end
+      ::ActiveRecord::Associations::Preloader.new(records: models, associations: [association_name]).call
     end
 
     def load?(model, association_name)

--- a/lib/goldiloader/compatibility.rb
+++ b/lib/goldiloader/compatibility.rb
@@ -2,21 +2,6 @@
 
 module Goldiloader
   module Compatibility
-    def self.pre_rails_7?
-      ::ActiveRecord::VERSION::MAJOR < 7
-    end
-
-    def self.rails_6_1?
-      ::ActiveRecord::VERSION::MAJOR == 6 && ::ActiveRecord::VERSION::MINOR == 1
-    end
-
-    def self.rails_6_1_or_greater?
-      ::ActiveRecord::VERSION::MAJOR > 6 || rails_6_1?
-    end
-
-    def self.pre_rails_7_2?
-      ::ActiveRecord::VERSION::MAJOR < 7 ||
-        (::ActiveRecord::VERSION::MAJOR == 7 && ::ActiveRecord::VERSION::MINOR < 2)
-    end
+    # Currently no Rails version compatibility issues to handle
   end
 end


### PR DESCRIPTION
This PR removes some dead code for old Rails versions.

@erikkessler1 - you're prime