### PR TITLE
Add Ruby 4.0 Testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: ruby:3.2.5
+      - image: ruby:3.2.10
     environment:
       BUNDLE_GEMFILE: gemfiles/rails_7.2.gemfile
     working_directory: ~/goldiloader
@@ -10,17 +10,18 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-gems-ruby-3.2.5-{{ checksum "goldiloader.gemspec" }}-{{ checksum "gemfiles/rails_7.2.gemfile" }}
-            - v1-gems-ruby-3.2.5-
+            - v1-gems-ruby-3.2.10-{{ checksum "goldiloader.gemspec" }}-{{ checksum "gemfiles/rails_7.2.gemfile" }}
+            - v1-gems-ruby-3.2.10-
       - run:
           name: Install Gems
           command: |
-            if ! bundle check --path=vendor/bundle; then
-              bundle install --path=vendor/bundle --jobs=4 --retry=3
+            bundle config set path 'vendor/bundle'
+            if ! bundle check; then
+              bundle install --jobs=4 --retry=3
               bundle clean
             fi
       - save_cache:
-          key: v1-gems-ruby-3.2.5-{{ checksum "goldiloader.gemspec" }}-{{ checksum "gemfiles/rails_7.2.gemfile" }}
+          key: v1-gems-ruby-3.2.10-{{ checksum "goldiloader.gemspec" }}-{{ checksum "gemfiles/rails_7.2.gemfile" }}
           paths:
             - "vendor/bundle"
             - "gemfiles/vendor/bundle"
@@ -52,8 +53,9 @@ jobs:
       - run:
           name: Install Gems
           command: |
-            if ! bundle check --path=vendor/bundle; then
-              bundle install --path=vendor/bundle --jobs=4 --retry=3
+            bundle config set path 'vendor/bundle'
+            if ! bundle check; then
+              bundle install --jobs=4 --retry=3
               bundle clean
             fi
       - unless:
@@ -84,9 +86,13 @@ workflows:
                 - gemfiles/rails_8.1.gemfile
                 - gemfiles/rails_edge.gemfile
               ruby_version:
-                - 3.2.5
-                - 3.3.5
-                - 3.4.5
+                - 3.2.10
+                - 3.3.10
+                - 3.4.9
+                - 4.0.2
+            exclude:
+              - gemfile: gemfiles/rails_edge.gemfile
+                ruby_version: 3.2.10
   weekly_rails_edge:
     triggers:
       - schedule:
@@ -102,4 +108,4 @@ workflows:
               gemfile:
                 - gemfiles/rails_edge.gemfile
               ruby_version:
-                - 3.3.5
+                - 4.0.2

--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 appraise 'rails-7.2' do
-  gem 'activerecord', '7.2.2.2'
-  gem 'activesupport', '7.2.2.2'
-  gem 'rails', '7.2.2.2'
+  gem 'activerecord', '7.2.3'
+  gem 'activesupport', '7.2.3'
+  gem 'rails', '7.2.3'
 end
 
 appraise 'rails-8.0' do
-  gem 'activerecord', '8.0.3'
-  gem 'activesupport', '8.0.3'
-  gem 'rails', '8.0.3'
+  gem 'activerecord', '8.0.4'
+  gem 'activesupport', '8.0.4'
+  gem 'rails', '8.0.4'
 end
 
 appraise 'rails-8.1' do
-  gem 'activerecord', '8.1.0.rc1'
-  gem 'activesupport', '8.1.0.rc1'
-  gem 'rails', '8.1.0.rc1'
+  gem 'activerecord', '8.1.2'
+  gem 'activesupport', '8.1.2'
+  gem 'rails', '8.1.2'
 end
 
 appraise 'rails-edge' do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Add Ruby 4.0 testing.
+
 ## 6.0.0
 - Add support for Ruby 3.4 and drop support for Ruby 3.0 and 3.1. Add support for Rails 8.1 and drop support for Rails
   6.1, 7.0, and 7.1. **Thanks [benaitcheson](https://github.com/benaitcheson)**

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "7.2.2.2"
-gem "activesupport", "7.2.2.2"
-gem "rails", "7.2.2.2"
+gem "activerecord", "7.2.3"
+gem "activesupport", "7.2.3"
+gem "rails", "7.2.3"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "8.0.3"
-gem "activesupport", "8.0.3"
-gem "rails", "8.0.3"
+gem "activerecord", "8.0.4"
+gem "activesupport", "8.0.4"
+gem "rails", "8.0.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -2,8 +2,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "8.1.0.rc1"
-gem "activesupport", "8.1.0.rc1"
-gem "rails", "8.1.0.rc1"
+gem "activerecord", "8.1.2"
+gem "activesupport", "8.1.2"
+gem "rails", "8.1.2"
 
 gemspec path: "../"

--- a/goldiloader.gemspec
+++ b/goldiloader.gemspec
@@ -36,14 +36,15 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'
-  spec.add_development_dependency 'combustion', '~> 1.3'
+  spec.add_development_dependency 'cgi'
+  spec.add_development_dependency 'combustion', '~> 1.5'
   spec.add_development_dependency 'coveralls_reborn', '>= 0.18.0'
   spec.add_development_dependency 'rails', '>= 7.2', '< 8.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rspec-rails'
-  spec.add_development_dependency 'salsify_rubocop', '~> 1.27'
+  spec.add_development_dependency 'salsify_rubocop', '~> 1.85'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3', '~> 2.0'
 end

--- a/lib/goldiloader/association_loader.rb
+++ b/lib/goldiloader/association_loader.rb
@@ -25,7 +25,7 @@ module Goldiloader
         model.association(association_name).auto_include?
     end
 
-    def has_association?(model, association_name) # rubocop:disable Naming/PredicateName
+    def has_association?(model, association_name) # rubocop:disable Naming/PredicatePrefix
       model.class.reflect_on_association(association_name).present?
     end
   end

--- a/spec/goldiloader/auto_include_context_spec.rb
+++ b/spec/goldiloader/auto_include_context_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'ostruct'
 
 AutoIncludeContextMockModel = Struct.new(:auto_include_context)
+AutoIncludeContextMockAssociation = Struct.new(:target)
 
 describe Goldiloader::AutoIncludeContext do
   describe ".register_models" do
@@ -157,7 +157,7 @@ describe Goldiloader::AutoIncludeContext do
       model = AutoIncludeContextMockModel.new
       associations.each do |association, models|
         allow(model).to receive(:association).with(association) do
-          OpenStruct.new(target: models)
+          AutoIncludeContextMockAssociation.new(models)
         end
       end
       model


### PR DESCRIPTION
This PR adds Ruby 4.0 to our a testing matrix. No production code changes were required to get it working. A few things to note:

* Ruby 4.0 removed the cgi library from Ruby installations so it needs to be an explicit development dependency
* Ruby 4.0 removed ostruct from the standard library so I removed our one test code dependency on it
* The version of bundler included in Ruby 4.0 dropped support for the `--path` argument so I needed to do a `bundle config set path` instead
* Rails Edge recently dropped support for Ruby 3.2
* I upgraded to the latest point releases of Ruby and Rails across the board
* I upgraded rubocop

